### PR TITLE
[#3] Ignore files that begin with underscore.

### DIFF
--- a/src/services/Navigation.php
+++ b/src/services/Navigation.php
@@ -117,7 +117,7 @@ class Navigation extends Component
     private static function _isHiddenFileOrDirectory(string $path): bool
     {
         return Collection::make(explode('/', $path))
-                ->filter(fn($segment) => str_starts_with($segment, '.'))
+                ->filter(fn($segment) => str_starts_with($segment, '.') || str_starts_with($segment, '_'))
                 ->isNotEmpty();
     }
 }


### PR DESCRIPTION
# Summary

This PR filters files from the Parts Kit that begin with an underscore.

## Issues

* #3 

## Testing Instructions

1. Add a file to the parts-kit directory that begins with an `_` (underscore)
2. The file should not be present in the Parts Kit navigation