### PR TITLE
[#15] Mock asset foundation: TDD plan + Assets service scaffold

### DIFF
--- a/docs/brainstorms/2026-05-25-mock-asset-brainstorm.md
+++ b/docs/brainstorms/2026-05-25-mock-asset-brainstorm.md
@@ -1,0 +1,190 @@
+# Mock Asset Service — Brainstorm
+
+**Date:** 2026-05-25
+**Status:** Brainstorm complete, ready for planning
+
+---
+
+## What We're Building
+
+A `MockAsset` element class plus a builder API that lets parts-kit template authors render placeholder images without needing real assets uploaded locally. Mocks behave enough like real `craft\elements\Asset` instances that typical Twig component templates (which call `asset.getUrl()`, `asset.getImg()`, `asset.alt`, `asset.focalPoint`, etc.) render correctly when handed a mock instead of a real asset.
+
+The motivating problem: Parts Kit renders example versions of Twig components. Those components frequently require a Craft asset, but local dev environments often don't have assets uploaded — and even when they do, asset state is not in sync across machines or fresh checkouts. The mock fills that gap.
+
+**Twig call site (target API):**
+
+```twig
+{# Terse: hash config #}
+{% set hero = partsKit.assets.make({
+  width: 1600,
+  height: 900,
+  label: 'Hero',
+  alt: 'Hero photo',
+}).one %}
+
+{# Or fluent: chained setters #}
+{% set thumb = partsKit.assets.make
+  .width(400)
+  .height(300)
+  .label('Thumbnail')
+  .one %}
+
+{# Component then uses the mock like any real asset #}
+{{ Image({ asset: hero, transform: 'hero' }) }}
+```
+
+---
+
+## Why This Approach
+
+### Path A: Override transform methods directly on `MockAsset`
+
+We extend `craft\elements\Asset`, override the four transform-producing methods (`getUrl`, `getImg`, `getSrcset`, `getUrlsBySize`) plus the asset surface that components actually touch (`alt`, `title`, `filename`, `extension`, `mimeType`, `kind`, focal point). All other Asset methods continue to throw `NotSupportedException` — the mock isn't trying to impersonate a complete `Asset`, only the subset components consume.
+
+**Considered and rejected: pre-generate + use Craft's native transform pipeline.** This would mean auto-provisioning a real Volume, writing real DB rows, and making the "mock" effectively a real (ephemeral) Asset. It's cleaner inside Craft's transform code but pulls a lot of state into the picture: a Volume must exist, DB grows with one row per unique size, and the mock stops being a mock.
+
+The user explicitly preferred no DB writes and no provisioned Volume, so Path A wins despite costing more code in `MockAsset` itself.
+
+### Imager X support via `EVENT_BEFORE_TRANSFORM_IMAGE`
+
+Imager X intercepts the transform call site (`craft.imagerx.transformImage(asset, transform)`), so our `getUrl` override never runs in projects that use it. Imager X reads source files through `LocalSourceImageModel`, which would crash on a fileless mock inside `getLocalCopy()`.
+
+**Solution:** the plugin registers a listener on `ImagerService::EVENT_BEFORE_TRANSFORM_IMAGE`. When `$event->image instanceof MockAsset`, the handler populates `$event->transformedImages` with a custom `MockTransformedImage` (modeled after `NoopImageModel`), short-circuiting the rest of the pipeline. Real assets fall through untouched.
+
+This requires an Imager X **Pro** license (the `transformedImages` short-circuit is Pro-gated). Viget's projects already use Pro. For OSS / Lite users we'll document the manual `noop: true` config-override fallback.
+
+A custom transformer (via `EVENT_REGISTER_TRANSFORMERS`) was considered but rejected — it would force template authors to opt in with `transformer: 'mock'` per call, while the event hook does it transparently based on asset type.
+
+### File storage: `@storage/runtime/parts-kit-mocks/`
+
+Generated PNGs live in `@storage/runtime/parts-kit-mocks/`, served by a plugin-registered controller route under the existing `/parts-kit/` URL namespace (so the existing `parts-kit:view` permission gate covers them automatically). Files are named by a SHA-1 hash of the full mock configuration, so identical configs produce identical URLs and the browser caches them. Lazy generation: files are written on first request, served from disk after.
+
+Rejected alternatives: base64 data URLs (bloats HTML, defeats caching, breaks transforms), `@webroot/cpresources` (wrong category — that folder is for asset bundles), arbitrary `@webroot/parts-kit-mocks/` (pollutes the project's webroot, permissions issues in some envs), placeholder services like `placehold.co` (requires internet, breaks transforms, third-party dependency).
+
+---
+
+## Key Decisions
+
+| Decision | Choice |
+|---|---|
+| **Asset behavior strategy** | Path A: override transform methods on `MockAsset`; keep `NotSupportedException` on everything else |
+| **Image delivery** | Real PNG files on disk, served via plugin controller route |
+| **Storage location** | `@storage/runtime/parts-kit-mocks/{hash}.png` |
+| **URL pattern** | `/parts-kit/mock/{hash}.png` (under existing parts-kit namespace, gated by `parts-kit:view`) |
+| **File naming** | SHA-1 hash of full mock config (width, height, label, format, etc.) |
+| **Caching headers** | `Cache-Control: max-age=31536000, immutable` (content-addressed URLs) |
+| **Cleanup** | Integrated with `php craft clear-caches/all` (storage/runtime is cache-clearable) |
+| **Imager X integration** | `EVENT_BEFORE_TRANSFORM_IMAGE` listener short-circuits with `MockTransformedImage` (requires Pro) |
+| **Imager X Lite fallback** | Documented only — users pass `{ noop: true }` manually |
+| **Visual customization** | Dimensions + optional `label` only. Always gray PNG. No bg color, text color, or format choice. |
+| **Twig API** | Both hash config (`make({...})`) AND fluent setters on the returned builder |
+| **Builder methods** | `width`, `height`, `label`, `alt`, `title`, `filename`, `focalPoint`, terminal `one` |
+| **Asset surface implemented** | dimensions, transforms, alt, title, filename, extension, mimeType, kind, focal point |
+| **Asset surface NOT implemented** | Custom fields, volume, folder, uploader, anything DB-backed |
+| **Image generator** | Imagick (already in place — generates gray PNG with centered dimension/label text) |
+
+---
+
+## Implementation Sketch (PHP-side)
+
+```php
+// services/Assets.php
+public function make(array $config = []): MockAssetBuilder
+{
+    return (new MockAssetBuilder())->configure($config);
+}
+
+// models/MockAssetBuilder.php
+public function configure(array $config): self
+{
+    foreach ($config as $key => $value) {
+        if (method_exists($this, $key)) {
+            $this->$key($value);
+        }
+    }
+    return $this;
+}
+
+public function width(int $v): self { /* ... */ }
+public function height(int $v): self { /* ... */ }
+public function label(string $v): self { /* ... */ }
+public function alt(string $v): self { /* ... */ }
+public function title(string $v): self { /* ... */ }
+public function filename(string $v): self { /* ... */ }
+public function focalPoint(array $v): self { /* ... */ }
+
+public function one(): MockAsset { /* ... */ }
+```
+
+```php
+// models/MockAsset.php — sketch of the transform-producing override
+public function getUrl(mixed $transform = null, ?bool $immediately = null): ?string
+{
+    [$w, $h] = $this->resolveTransformDimensions($transform);
+    $hash = sha1(json_encode([
+        'width' => $w,
+        'height' => $h,
+        'label' => $this->label,
+    ]));
+    $path = Craft::getAlias('@storage/runtime/parts-kit-mocks/' . $hash . '.png');
+    if (!file_exists($path)) {
+        $this->generatePng($path, $w, $h, $this->label);
+    }
+    return UrlHelper::actionUrl('parts-kit/mock/view', ['hash' => $hash]);
+}
+```
+
+```php
+// Plugin.php — Imager X integration (in attachEventHandlers)
+if (class_exists(ImagerService::class)) {
+    Event::on(
+        ImagerService::class,
+        ImagerService::EVENT_BEFORE_TRANSFORM_IMAGE,
+        function (TransformImageEvent $event) {
+            if (!$event->image instanceof MockAsset) {
+                return;
+            }
+            $event->transformedImages = array_map(
+                fn(array $t) => new MockTransformedImage($event->image, $t),
+                $event->transforms
+            );
+        }
+    );
+}
+```
+
+---
+
+## Resolved Questions
+
+1. **Default dimensions (unset width/height):** Default to **800×600**. `partsKit.assets.make.one` with no setters renders an 800×600 gray PNG.
+
+2. **Filename defaults & derivation:** Default filename is **`mock-{width}x{height}.png`**. When `->filename('hero.jpg')` is set, extension/mimeType/kind are **auto-derived** from the filename. Single source of truth.
+
+3. **Focal point default:** **`null`**, with `hasFocalPoint()` returning `false`. Faithful to Craft's real behavior — focal points are opt-in on real assets. Users set explicitly via `->focalPoint([0.3, 0.7])`.
+
+4. **Non-image asset kinds:** **Image-only in v1.** `kind` always returns `'image'` regardless of the filename. Document the limitation; revisit only if a real component needs PDF/video mocking.
+
+5. **Hash inputs:** **Config only** — `sha1(width|height|label|...)`. No plugin version prefix. Invalidation happens via `php craft clear-caches/all`, consistent with the rest of Craft.
+
+6. **Imager X Lite (OSS) experience:** **Document only.** No runtime auto-injection. README explains the manual `{ noop: true }` workaround for Lite users. Viget projects use Pro, so the event-hook path is the supported path.
+
+7. **Plugin config knobs:** **Hardcoded for v1.** Storage at `@storage/runtime/parts-kit-mocks/`, URL at `/parts-kit/mock/`. Add config knobs only if a concrete need emerges.
+
+---
+
+## Out of Scope (Explicit YAGNI)
+
+- Custom fields on mocks (`->set('caption', ...)`)
+- Background color / text color customization
+- Format choice (always PNG)
+- Pluggable image generators (picsum, AI, custom callbacks)
+- Real Craft transform pipeline running on mock files (avoided to keep the design DB-free and Volume-free)
+- Imager X Pro custom transformer registration (event-hook approach is cleaner for this use case)
+- Mocking non-image asset kinds (PDFs, videos)
+
+---
+
+## Next Step
+
+Run `/workflows:plan` to convert this brainstorm into an implementation plan.

--- a/docs/plans/2026-05-25-feat-mock-asset-service-plan.md
+++ b/docs/plans/2026-05-25-feat-mock-asset-service-plan.md
@@ -3,10 +3,31 @@ title: Mock Asset Service for Parts Kit
 type: feat
 status: active
 date: 2026-05-25
+revised: 2026-06-08
 brainstorm: docs/brainstorms/2026-05-25-mock-asset-brainstorm.md
 ---
 
 # feat: Mock Asset Service for Parts Kit
+
+> **2026-06-08 TDD rework.** This plan was restructured to a test-first execution
+> strategy now that the repo has a working Codeception suite (unit + functional
+> through the `\craft\test\Craft` connector), PHPStan level 4, and ECS. Two facts
+> from a fresh codebase audit reshaped the phases:
+>
+> 1. **The feature is 100% greenfield.** Despite the original plan describing a
+>    "WIP `MockAsset`" with bugs to fix, none of `MockAsset`, `MockAssetBuilder`,
+>    the `Assets` service, or any controller/helper exists today. `Plugin.php` has
+>    no `assets` component and no `@property-read` typo. **Phase 1 is therefore
+>    scaffolding, not cleanup.**
+> 2. **CI already loads `ext-imagick`.** Both `.github/workflows/ci.yml` and
+>    `.github/workflows/codecept.yml` list `imagick` in `PHP_EXTENSIONS`, so
+>    image-generation tests run in CI with no workflow change — the only code
+>    change needed is adding `ext-imagick` to `composer.json`'s `require`.
+>
+> The design decisions in the Enhancement Summary below are unchanged and remain
+> authoritative. What changed is *how the work is sequenced and verified*: every
+> feature-bearing unit now leads with a failing test, and the acceptance criteria
+> are mapped to concrete Codeception test files instead of manual verification.
 
 ## Enhancement Summary
 
@@ -15,81 +36,72 @@ brainstorm: docs/brainstorms/2026-05-25-mock-asset-brainstorm.md
 
 ### Refinements applied
 
-1. **Phase split.** Phase 1 (foundation cleanup — constructor fix, `@property-read` typo, `getAssets()` getter) lands as a small separate PR before the feature work. Phase 2 starts on a clean base.
-2. **Builder pattern correction.** `MockAssetBuilder` now holds a config array and constructs the `MockAsset` in `one()` via `new MockAsset($config)`. No more mutating a half-built Asset mid-chain. Aligns with Yii's standard `new X($config)` idiom.
-3. **Imager X integration extracted to a service.** `src/services/ImagerXIntegration.php` registers conditionally in `Plugin::config()` under `class_exists`. Keeps the soft-dependency surface in one file, matches existing Navigation/Assets service pattern.
-4. **URL construction + signing extracted from `MockAsset`.** New `Assets::signedUrlForImage(int $w, int $h, ?string $label): string` method owns both routing and HMAC signing. The element no longer knows the controller's routing decision.
-5. **Performance: fully lazy, controller-only generation.** Template rendering does **zero** Imagick and zero filesystem work — `getUrl()`/`getImg()`/`getSrcset()` only emit signed URL strings. Every PNG is generated inside `MockController` on the first HTTP request for its URL, then cached. This drops render time for a 20-mock page to near-zero (no longer ~2-4s) and removes the per-request generation guard entirely.
-6. **Extensibility: keyed signed payload + transform normalization.** The signed payload is a keyed array (`['w'=>…, 'h'=>…, 'label'=>…]`), so future knobs (`format`, `bg`, `position`) slot in additively without breaking existing decode. All transform argument shapes — named handles (`'hero-transform'`), arrays, and `ImageTransform` objects — are normalized via `ImageTransforms::normalizeTransform()` before dimension resolution, so mode-aware sizing (crop/fit/stretch/letterbox) works uniformly.
-7. **Performance: drop ETag + 304.** `Cache-Control: public, max-age=31536000, immutable` is sufficient. Removes filemtime syscall, conditional-request branching, and NFR4 entirely.
-8. **Security: tamper-proof signed URLs + visibility mirrors Parts Kit.** Mock URLs carry an HMAC-signed payload (`Security::hashData`/`validateData` — the primitive behind Craft's `|hash` filter); the controller validates the signature and rejects any tampering with a 404. Access is **no longer** devMode-gated: a mock image is viewable by exactly whoever can view the Parts Kit (public, or `parts-kit:view`-gated, per `requireViewPermission`). Signing is what makes opening access safe — forged dimensions/labels are impossible without the app security key. Replaces the earlier `ForbiddenHttpException` hard-block.
+1. **Phase split.** Phase 1 (foundation — `Assets` service scaffold, component registration, `getAssets()` getter, typed-getter/`@property-read` convention) lands as a small separate PR before the feature work. Phase 2 starts on a clean base.
+2. **Builder pattern correction.** `MockAssetBuilder` holds a config array and constructs the `MockAsset` in `one()` via `new MockAsset($config)`. No mutating a half-built Asset mid-chain. Aligns with Yii's standard `new X($config)` idiom.
+3. **Imager X integration extracted to a service.** `src/services/ImagerXIntegration.php` registers conditionally under `class_exists`. Keeps the soft-dependency surface in one file, matches existing Navigation/Assets service pattern.
+4. **URL construction + signing extracted from `MockAsset`.** `Assets::signedUrlForImage(int $w, int $h, ?string $label): string` owns both routing and HMAC signing. The element no longer knows the controller's routing decision.
+5. **Performance: fully lazy, controller-only generation.** Template rendering does **zero** Imagick and zero filesystem work — `getUrl()`/`getImg()`/`getSrcset()` only emit signed URL strings. Every PNG is generated inside `MockController` on the first HTTP request for its URL, then cached.
+6. **Extensibility: keyed signed payload + transform normalization.** The signed payload is a keyed array (`['w'=>…, 'h'=>…, 'label'=>…]`), so future knobs slot in additively. All transform argument shapes — named handles, arrays, and `ImageTransform` objects — are normalized via `ImageTransforms::normalizeTransform()` before dimension resolution.
+7. **Performance: drop ETag + 304.** `Cache-Control: public, max-age=31536000, immutable` is sufficient. Removes filemtime syscall and conditional-request branching.
+8. **Security: tamper-proof signed URLs + visibility mirrors Parts Kit.** Mock URLs carry an HMAC-signed payload (`Security::hashData`/`validateData`); the controller validates the signature and rejects tampering with a 404. Access is **not** devMode-gated: a mock image is viewable by exactly whoever can view the Parts Kit.
 9. **Security: reorder access check before signature validation.** The controller runs its permission gate before validating the token, so unauthorized requests get a uniform 403 and can't probe which tokens are valid.
-10. **Security: hardcode `sendFile` disposition filename to `'mock.png'`.** Removes defense-in-depth concern about user-controlled header content.
-11. **Security: use `NotFoundHttpException` for 404, not custom response body.** Eliminates any future XSS risk from interpolated hash echo.
-12. **Security: cap label length at 200 chars** in `MockAssetBuilder::label()` to bound `queryFontMetrics` cost.
-13. **Security: cap directory file count at 5,000** in `MockImageGenerator::generate()`. Bounds disk-fill via malicious template loop.
-14. **LSP violation acknowledgment.** `MockAsset` class docblock explicitly states the structural-subtype contract — only read-time transform APIs are honored, mutations and persistence are unsupported by design.
-15. **Cut: static error PNG fallback.** Generation failure now lets the exception bubble. In dev, broken image = real signal, not noise to mask.
-16. **Cut: per-render devMode warning logging.** Replaced by the Parts Kit visibility gate plus tamper-proof signed URLs (item 8).
-17. **Cut: Lite-license boot detection.** README note suffices. Viget uses Pro anyway.
-18. **Cut: `@method` PHPDoc block on MockAsset.** Goes stale; `NotSupportedException` messages are the source of truth.
-19. **Durable URLs for free.** Because the signed token carries the (validated) config, the controller generates the PNG on demand — both on first request and after a cache clear — with no sidecar `{hash}.json` files and no 404-then-refresh. Generation is controller-only; there is no render-time generation path.
+10. **Security: hardcode `sendFile` disposition filename to `'mock.png'`.**
+11. **Security: use `NotFoundHttpException` for 404, not custom response body.**
+12. **Security: cap label length at 200 chars** in `MockAssetBuilder::label()`.
+13. **Security: cap directory file count at 5,000** in `MockImageGenerator::generate()`.
+14. **LSP violation acknowledgment.** `MockAsset` class docblock explicitly states the structural-subtype contract.
+15. **Cut: static error PNG fallback.** Generation failure lets the exception bubble.
+16. **Cut: per-render devMode warning logging.**
+17. **Cut: Lite-license boot detection.** README note suffices.
+18. **Cut: `@method` PHPDoc block on MockAsset.** `NotSupportedException` messages are the source of truth.
+19. **Durable URLs for free.** The signed token carries the validated config, so the controller generates the PNG on demand — first request and after a cache clear — with no sidecar files.
 
 ### Rejected suggestions (with reasoning)
 
-- **Cut bundled DejaVuSans.ttf** — best-practices research showed this is the standard Craft-community pattern. Removing it surfaces portability bugs on Alpine/slim Docker images. ~750KB is a fair price.
-- **Cut fluent setters, keep only `configure(array)`** — user explicitly chose both in the brainstorm. Reviewer didn't see that decision.
-- **Inline `MockImageGenerator` as a private method** — architecture review confirmed static helper is the right fit; the file isolation aids future refactors.
-- **Cut atomic temp-file + rename** — 5 lines of code for a real correctness property under concurrency. Keep.
+- **Cut bundled DejaVuSans.ttf** — standard Craft-community pattern; removing it surfaces portability bugs on slim Docker images. ~750KB is a fair price.
+- **Cut fluent setters, keep only `configure(array)`** — user explicitly chose both in the brainstorm.
+- **Inline `MockImageGenerator` as a private method** — static helper is the right fit; file isolation aids future refactors and **testability** (a key TDD enabler — see Testing Strategy).
+- **Cut atomic temp-file + rename** — 5 lines for a real correctness property under concurrency. Keep.
 
 ### New considerations discovered
 
 - A malicious template can fill `@storage/runtime/parts-kit-mocks/` by looping unique hashes. Bounded by 5,000-file cap.
-- Future v2 security notes added for pluggable generators (RCE shape), custom field support (cache collision), and config knobs for storage path (arbitrary file overwrite via rename).
-- Viget consumer projects should be audited for `Asset $param` type-hints to confirm component code accepts MockAsset via the extends-Asset path (vs untyped duck-typing).
+- Future v2 security notes for pluggable generators (RCE shape), custom field support (cache collision), and config knobs for storage path (arbitrary file overwrite via rename).
+- Viget consumer projects should be audited for `Asset $param` type-hints.
 
 ---
 
 ## Overview
 
-Add a fully functional `MockAsset` element class (extending `craft\elements\Asset`) and a fluent / hash-config builder API so that Parts Kit template authors can render placeholder images without needing real assets uploaded locally. The mock generates real PNG files on disk lazily — on the first request for each URL (cached by SHA-1 hash of config) — serves them through a plugin controller route addressed by a **tamper-proof, HMAC-signed URL**, and integrates transparently with both Craft's native transform pipeline and Imager X (Pro) via `EVENT_BEFORE_TRANSFORM_IMAGE`. Image access **mirrors Parts Kit visibility** — if a user can view the Parts Kit, they can load its mock images.
+Add a fully functional `MockAsset` element class (extending `craft\elements\Asset`) and a fluent / hash-config builder API so that Parts Kit template authors can render placeholder images without real assets uploaded locally. The mock generates real PNG files on disk lazily — on the first request for each URL (cached by SHA-1 hash of config) — serves them through a plugin controller route addressed by a **tamper-proof, HMAC-signed URL**, and integrates transparently with both Craft's native transform pipeline and Imager X (Pro). Image access **mirrors Parts Kit visibility**.
 
 ## Problem Statement
 
-Parts Kit lets developers preview Twig components in isolation — but most production components consume Craft `Asset` instances (for images: hero photos, thumbnails, avatars, etc.). In local development:
+Parts Kit lets developers preview Twig components in isolation — but most production components consume Craft `Asset` instances. In local development assets aren't synced from production, asset IDs differ across machines, and setting up a real asset just to preview a component is high-friction for a no-setup dev tool.
 
-1. Assets are not in sync with production (no CDN backfill, no fresh-checkout dump),
-2. Asset IDs differ across machines and environments,
-3. Setting up a real asset just to preview a component is high-friction work for what should be a no-setup dev tool.
-
-The existing WIP `MockAsset` class extends `Asset` but throws `NotSupportedException` on ~95% of methods and renders a base64 PNG inline. This breaks the moment a component calls `asset.getImg()`, `asset.getUrl({width: 400})`, `asset.alt`, or any transform pipeline. It also bloats HTML and defeats browser caching.
+The mock must implement the **subset of `Asset` that real-world Twig component templates actually use** (dimensions, transforms, alt, title, filename/extension/mimeType/kind, focal point) and route image production through a plugin controller serving real PNG files — without inline base64, without DB writes, and without breaking the moment a component calls `asset.getImg()` or runs a transform.
 
 ## Proposed Solution
 
-A complete rewrite of `MockAsset` that implements the **subset of `Asset` that real-world Twig component templates actually use** (dimensions, transforms, alt, title, filename/extension/mimeType/kind, focal point) and routes image production through a plugin controller serving real PNG files from `@storage/runtime/parts-kit-mocks/`. Each mock URL is a **tamper-proof, HMAC-signed token** (via Yii's `Security`, surfaced in Craft as the `|hash` filter); the controller validates the signature and, because the validated config travels in the URL, **lazily generates the PNG on the first request** (and regenerates it after any cache clear). Template rendering itself performs no image generation — it only emits signed URLs. Image access **mirrors Parts Kit visibility** rather than gating on devMode. Imager X integration uses an `EVENT_BEFORE_TRANSFORM_IMAGE` listener that populates `transformedImages` with a custom `MockTransformedImage` model, transparently short-circuiting the pipeline for mocks.
+A complete `MockAsset` implementation routing image production through a plugin controller serving real PNG files from `@storage/runtime/parts-kit-mocks/`. Each mock URL is a **tamper-proof, HMAC-signed token** (via Yii's `Security`); the controller validates the signature and, because the validated config travels in the URL, **lazily generates the PNG on the first request** (and regenerates after any cache clear). Template rendering itself performs no image generation — it only emits signed URLs. Imager X integration uses an `EVENT_BEFORE_TRANSFORM_IMAGE` listener populating `transformedImages` with a `MockTransformedImage`.
 
 **Target Twig usage:**
 
 ```twig
 {# Hash config — terse #}
 {% set hero = partsKit.assets.make({
-  width: 1600,
-  height: 900,
-  label: 'Hero',
-  alt: 'Hero photo',
+  width: 1600, height: 900, label: 'Hero', alt: 'Hero photo',
 }).one %}
 
 {# Or fluent chain — incremental #}
-{% set thumb = partsKit.assets.make
-  .width(400)
-  .height(300)
-  .label('Thumbnail')
-  .one %}
+{% set thumb = partsKit.assets.make.width(400).height(300).label('Thumbnail').one %}
 
 {# Components consume mocks identically to real assets #}
 {{ Image({ asset: hero, transform: 'hero-transform' }) }}
 {{ craft.imagerx.transformImage(hero, { width: 800, mode: 'fit' }) }}
 ```
+
+---
 
 ## Technical Approach
 
@@ -101,363 +113,559 @@ flowchart TD
     B -->|new MockAssetBuilder| C[MockAssetBuilder]
     C -->|->one| D[MockAsset element]
     A -->|asset.getUrl/getImg| D
-    D -->|signs URL (no generation)| E[/parts-kit/mock/&lt;signed-token&gt;.png]
+    D -->|signs URL no generation| E[/parts-kit/mock/&lt;signed-token&gt;.png]
     E -->|HTTP GET| F[MockController::actionView<br/>Parts Kit gate + validateData]
     F -->|sendFile| G[(@storage/runtime/parts-kit-mocks/&lt;hash&gt;.png)]
-    F -.->|first request / miss → generate from validated config| H[MockImageGenerator]
+    F -.->|first request / miss → generate| H[MockImageGenerator]
     H -.->|atomic write| G
-    I[craft.imagerx.transformImage] -->|ImagerService::EVENT_BEFORE_TRANSFORM_IMAGE| J[Plugin event listener]
+    I[craft.imagerx.transformImage] -->|EVENT_BEFORE_TRANSFORM_IMAGE| J[ImagerXIntegration listener]
     J -->|asset instanceof MockAsset?| K{Yes?}
-    K -->|Yes| L[Populate $event->transformedImages with MockTransformedImage]
+    K -->|Yes| L[Populate transformedImages with MockTransformedImage]
     K -->|No| M[Pass through to default transformer]
     L -->|points at MockAsset URL| E
 ```
 
 ### File Inventory
 
-| File | Purpose | Status |
+Every file below is **new** — confirmed by a 2026-06-08 audit. Each feature-bearing source file is paired with its test file.
+
+| Source file | Purpose | Test file |
 |---|---|---|
-| `src/Plugin.php` | Add URL rule, ClearCaches registration, `getAssets()` getter, fix `@property-read` typo. Imager X registration deferred to `ImagerXIntegration` service | Modify |
-| `src/services/Assets.php` | `make(array $config = [])` returns configured `MockAssetBuilder`; boot-time Imagick check; `signedUrlForImage(int $w, int $h, ?string $label): string` builds the tamper-proof HMAC-signed URL | Modify |
-| `src/services/ImagerXIntegration.php` | Conditionally registers `EVENT_BEFORE_TRANSFORM_IMAGE` listener; isolates soft-dependency surface | New |
-| `src/models/MockAsset.php` | Full rewrite: implements supported asset surface, overrides four transform methods to emit signed URLs (no generation at render), retains `NotSupportedException` for the rest with helpful messages. Class docblock acknowledges LSP violation as intentional | Rewrite |
-| `src/models/MockAssetBuilder.php` | Holds config array, constructs `MockAsset` in `one()`. Adds `configure(array)`, `label` (200-char cap), `alt`, `title`, `filename`, `focalPoint` builder methods | Extend |
-| `src/models/MockTransformedImage.php` | Implements `TransformedImageInterface` for Imager X short-circuit | New |
-| `src/helpers/MockImageGenerator.php` | Imagick PNG generation invoked only by the controller; `generate()`, font detection, atomic write, scale-to-fit text, file-count cap | New |
-| `src/controllers/MockController.php` | `actionView(string $token): Response` — access mirrors Parts Kit visibility; validates HMAC signature (404 on tamper); lazily generates the PNG from validated config on first request; serves PNG via `sendFile` with hardcoded disposition filename | New |
-| `src/resources/fonts/DejaVuSans.ttf` | Bundled font (DejaVu Sans — Bitstream Vera license, redistributable) | New |
-| `composer.json` | Add `"ext-imagick": "*"` to require | Modify |
-| `README.md` | Document Mock Asset API, Imager X Pro/Lite behavior, supported surface, "dev-only" guarantee | Modify |
+| `src/Plugin.php` *(modify)* | Register `assets` + `imagerXIntegration` components, `getAssets()` getter + `@property-read`, URL rule, ClearCaches registration, call `ImagerXIntegration::register()` | `tests/unit/PluginWiringTest.php` |
+| `src/services/Assets.php` | `make()` returns configured `MockAssetBuilder`; boot Imagick check; `signedUrlForImage()` builds the HMAC-signed URL | `tests/unit/services/AssetsTest.php` |
+| `src/services/ImagerXIntegration.php` | Conditionally registers `EVENT_BEFORE_TRANSFORM_IMAGE`; isolates soft-dependency | `tests/unit/services/ImagerXIntegrationTest.php` |
+| `src/models/MockAsset.php` | Implements supported asset surface; transform methods emit signed URLs (no generation at render); `NotSupportedException` for the rest | `tests/unit/models/MockAssetTest.php` |
+| `src/models/MockAssetBuilder.php` | Holds config array, constructs `MockAsset` in `one()`; fluent setters + `configure()` | `tests/unit/models/MockAssetBuilderTest.php` |
+| `src/models/MockTransformedImage.php` | Implements Imager X `TransformedImageInterface` | `tests/unit/models/MockTransformedImageTest.php` |
+| `src/helpers/MockImageGenerator.php` | Imagick PNG generation invoked only by the controller; atomic write, scale-to-fit, file-count cap | `tests/unit/helpers/MockImageGeneratorTest.php` |
+| `src/controllers/MockController.php` | `actionView(string $token)` — Parts Kit gate, HMAC validation, lazy generation, `sendFile` | `tests/functional/MockControllerCest.php` |
+| `src/resources/fonts/DejaVuSans.ttf` | Bundled font (Bitstream Vera license, redistributable) | covered indirectly by `MockImageGeneratorTest` |
+| `composer.json` *(modify)* | Add `"ext-imagick": "*"` to `require` | `composer validate` |
+| `README.md` / `CHANGELOG.md` *(modify)* | Document Mock Asset API, Imager X behavior, supported surface | n/a (docs) |
 
-### Implementation Phases
+### Output Structure
 
-#### Phase 1: Foundation cleanup (separate PR)
+New paths this plan introduces (existing `src/` tree omitted):
 
-Small, mergeable-on-its-own PR that fixes latent bugs unrelated to the mock asset feature. Lands first so Phase 2 builds on a clean base.
+```
+src/
+├── controllers/
+│   └── MockController.php          # new
+├── helpers/                        # new namespace (first occupant)
+│   └── MockImageGenerator.php
+├── models/
+│   ├── MockAsset.php               # new
+│   ├── MockAssetBuilder.php        # new
+│   └── MockTransformedImage.php    # new
+├── resources/                      # new
+│   └── fonts/
+│       └── DejaVuSans.ttf
+└── services/
+    ├── Assets.php                  # new
+    └── ImagerXIntegration.php      # new
+tests/
+├── unit/
+│   ├── PluginWiringTest.php
+│   ├── helpers/MockImageGeneratorTest.php
+│   ├── models/MockAssetBuilderTest.php
+│   ├── models/MockAssetTest.php
+│   ├── models/MockTransformedImageTest.php
+│   └── services/
+│       ├── AssetsTest.php
+│       └── ImagerXIntegrationTest.php
+└── functional/
+    └── MockControllerCest.php
+```
 
-**Tasks**
+---
 
-- [ ] Fix `MockAsset::__construct()` to accept `$config = []` and call `parent::__construct($config)`. Current empty no-arg breaks `new MockAsset(['width' => 800])`.
-- [ ] Fix `MockAsset::init()` to call `parent::init()`. Per Craft 5 source (`Asset::init()` line 1288), init is minimal, no DB lookups, safe to call.
-- [ ] Fix `Plugin.php` `@property-read Assets $assetService` → `@property-read Assets $assets` to match actual component key.
-- [ ] Add `getAssets(): Assets` getter to `Plugin.php` mirroring the existing `getNavigation()` pattern.
-- [ ] Audit `getNavigation()` for the same drift — if `@property-read Navigation $navigation` is missing, add it. Establish convention: every component in `config()['components']` gets a typed getter AND a matching `@property-read` line.
-- [ ] Run `composer check-cs` and `composer phpstan` clean before moving on.
+## Testing Strategy
 
-**Note:** `composer.json` ext-imagick addition and bundled font moved to Phase 2 — they're feature dependencies, not foundation cleanup.
+This is the spine of the rework. Read it before the implementation units — it defines the suite split, the harness affordances each unit relies on, and the handful of things that genuinely *cannot* be asserted in CI.
 
-**Success criteria:** Existing parts-kit functionality unchanged; static analysis passes; `new MockAsset(['width' => 800])` instantiates without exception; this PR lands cleanly before Phase 2 begins.
+### Suite split
 
-#### Phase 2: Core mock implementation
+- **Unit suite (`tests/unit/`)** — the bulk of coverage. The `\craft\test\Craft` module boots a full Craft app with a real DB and rolls back per test, so unit tests can call `Craft::$app->getSecurity()`, `UrlHelper::siteUrl()`, instantiate elements, and resolve transforms. Use unit tests for: the builder, the `Assets` service (URL signing + round-trip), `MockAsset` (dimension math, metadata, render-time URL emission, `NotSupportedException`), `MockImageGenerator` (real PNG output — `imagick` is loaded in CI), the cache-option registration, and the Imager X guard.
+- **Functional suite (`tests/functional/`)** — HTTP-level behavior of `MockController` only. The functional connector renders through `\craft\test\Craft` (proven by `tests/functional/PartsKitRouteCest.php`), so `$I->amOnPage()`, `$I->seeResponseCodeIs()`, response headers, and `$I->amLoggedInAs()` all work. Use it for the route: 200 + headers + real PNG bytes, tamper → 404, permission gate (403/200), cold-cache lazy generation.
 
-The meaty phase — write everything the Craft transform pipeline touches.
+### Harness affordances to lean on
 
-**Feature dependencies added in this phase:**
+- **Signing round-trips in-process.** `tests/.env`/CI set a fixed `SECURITY_KEY`, so `Assets::signedUrlForImage()` and `Security::validateData()` are deterministic within a test run. Assert sign→validate round-trips and that a one-byte mutation fails validation — no HTTP needed for the crypto itself.
+- **Real PNGs are cheap to assert.** `MockImageGeneratorTest` writes to a temp dir (`Craft::getAlias('@storage/runtime/...')` or `codecept_output_dir()`), then asserts pixel dimensions with `getimagesize()` and PNG signature bytes. `imagick` is present in CI (`PHP_EXTENSIONS` already includes it).
+- **Prefer array/`ImageTransform` transforms over named handles in tests.** `ImageTransforms::normalizeTransform()` resolves named handles (`'hero-transform'`) by DB lookup, which the harness won't have. Tests should pass `['width' => 400, 'mode' => 'fit']` or a constructed `ImageTransform` to exercise dimension math without a DB transform row. The named-handle path is covered by the manual AC8 check.
+- **`--env fast`** skips the DB rebuild between runs; the suite must run once without it first to build the schema. Use it for the inner TDD loop.
 
-- [ ] Add `"ext-imagick": "*"` to `composer.json` `require`.
-- [ ] Create `src/resources/fonts/` directory and add `DejaVuSans.ttf` (Bitstream Vera license, redistributable). Ensure included in composer package via default plugin autoload.
+### What cannot be auto-tested (explicitly manual)
 
-**Tasks**
+- **AC8 (Imager X Pro short-circuit)** requires `spacecatninja/imager-x` installed with a Pro license — not a CI dependency (soft dep via `class_exists`). `MockTransformedImageTest` and the integration test **skip themselves** when `ImagerXIntegration::isAvailable()` is false (`$this->markTestSkipped(...)`), and AC8 is verified manually in the DDEV harness with Imager X installed. NFR5 (boots cleanly *without* Imager X) is the auto-tested half and is the CI default.
+- **`NFR4` (Imagick missing → `RuntimeException`)** can't be exercised in CI because `imagick` is always loaded there. Cover the *message/throw shape* by asserting the guard exists and is reachable; verify the actual missing-extension path manually on an Imagick-less environment, or extract the check to a testable seam (`extension_loaded` wrapper) only if it proves necessary — do not over-engineer for it.
 
-- [ ] **`MockImageGenerator` helper** (`src/helpers/MockImageGenerator.php`):
-  - Class-level docblock explains: stateless static helper, first occupant of the `helpers/` namespace, isolated for testability and future refactor.
-  - Static `generate(string $path, int $width, int $height, ?string $label): void` — the only generation entry point; called exclusively from `MockController` on a cache miss.
-  - Font detection chain: bundled `DejaVuSans.ttf` → `/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf` → `/System/Library/Fonts/Helvetica.ttc` → throw `RuntimeException` with install hint
-  - Render: bg `#999999` (AA-contrast with white text), centered white label
-  - Default label: `"{$width}x{$height}"`; respect user-provided override
-  - Scale-to-fit: start `(int)(min($w, $h) * 0.2)`, use `queryFontMetrics()` to step down until fit, floor at 8px
-  - PNG output: `setImageFormat('png')`, `setImageCompressionQuality(75)`, `stripImage()`
-  - **Atomic write**: write to `$path.tmp.{bin2hex(random_bytes(8))}` then `rename()` to final path
-  - **File-count cap (security):** before writing, count `*.png` files in the directory. If > 5,000, log `Craft::warning('parts-kit mocks cache full')` and abort generation (callers handle missing file as a normal cache miss).
-  - **NO try/catch fallback** — let Imagick exceptions bubble. In dev, broken image is the desired signal that the env is broken (Imagick missing, no fonts, disk full). The `MockAsset::getUrl()` caller can decide whether to swallow.
+### Execution-posture default
 
-- [ ] **`MockAsset` rewrite** (`src/models/MockAsset.php`):
-  - Class docblock explicitly acknowledges LSP violation:
-    ```
-    /**
-     * MockAsset is a structural subtype of craft\elements\Asset, honoring ONLY
-     * the read-time transform/metadata APIs needed by typical Twig component
-     * templates. Mutations, persistence, field access, and volume-related calls
-     * are intentionally unsupported and will throw NotSupportedException.
-     * This violates LSP by design; the alternative (a composition wrapper) cannot
-     * pass Craft/ImagerX type-hints that require `craft\elements\Asset`.
-     */
-    ```
-  - Extend `craft\elements\Asset`
-  - Restore `__construct($config = [])`, `init()` (Phase 1 already done)
-  - In `init()`: set sane defaults — `$this->id = -1`, `$this->kind = Asset::KIND_IMAGE`, `setScenario(self::SCENARIO_CREATE)`
-  - **Private typed properties for builder-set values:** `?int $_width`, `?int $_height`, `?string $_label`, `?string $_filename`, `?array $_focalPoint`. The `alt` and `title` properties are inherited from `Asset` / `Element` and used directly.
-  - **Per-instance URL memo:** `private array $_urlCache = [];` — keyed by normalized transform args; caches the signed URL string so repeated `getUrl()` calls skip re-signing. No generation or filesystem access is involved (generation is controller-only).
-  - **Override transform-producing methods** with exact Craft 5 signatures:
-    - `getUrl(mixed $transform = null, ?bool $immediately = null): ?string` — memoized; normalizes `$transform` via `ImageTransforms::normalizeTransform()`, resolves it to the final width/height, then delegates to `Plugin::getInstance()->getAssets()->signedUrlForImage($w, $h, $this->_label)`. Emits a URL only — no generation.
-    - `getImg(mixed $transform = null, ?array $sizes = null): ?Markup` — mirror Craft's default: `Html::tag('img', '', ['src', 'width', 'height', 'srcset', 'alt'])`. Returns null when `$this->kind !== Asset::KIND_IMAGE` (matches Craft).
-    - `getSrcset(array $sizes, mixed $transform = null): string|false` — composes the srcset string purely from signed URLs (one per size, via `signedUrlForImage`). No generation: each size's PNG is created lazily by the controller when the browser fetches that URL.
-    - `getUrlsBySize(array $sizes, mixed $transform = null): array`
-  - **Override `getWidth(array|string|ImageTransform $transform = null): ?int`** — note the typed union, NOT `mixed` (LSP). Normalize `$transform` via `ImageTransforms::normalizeTransform()` first (so named handles, arrays, and `ImageTransform` objects all resolve), then compute via `Image::targetDimensions($this->_width, $this->_height, $t->width, $t->height, $t->mode, $t->upscale)`. This is mode-aware: `crop`, `fit`, `stretch`, and `letterbox` all yield the correct target size (a placeholder has no subject to crop, so mode only affects dimensions).
-  - **Override `getHeight(mixed $transform = null): ?int`** — same normalization + dimension resolution.
-  - **Implement metadata getters/setters:** `getFilename()`, `setFilename()`, `getExtension()`, `getMimeType()`, `getHasFocalPoint()`, `getFocalPoint()`, `setFocalPoint()`.
-  - **Filename auto-derivation:** default filename `mock-{w}x{h}.png`. When `setFilename('hero.jpg')` is called, derive extension/mimeType from the path. `kind` remains `'image'` always in v1.
-  - **Signed payload & cache key:** the canonical payload is a **keyed** array, `Json::encode(['w' => $w, 'h' => $h, 'label' => $this->_label], JSON_THROW_ON_ERROR)` — keyed (not positional) so future fields (`format`, `bg`, `position`) are additive and don't break decode. The URL token is `Security::hashData($payload)`, URL-safe-encoded; the on-disk cache filename is `sha1($payload)`. The controller (post-`validateData`) recomputes `sha1($payload)` to locate or generate the file. **Extension points:** add a key here, read it in `MockController`, and pass it through to `MockImageGenerator::generate()` — the signature and cache key absorb the new field automatically (new config ⇒ new hash ⇒ fresh PNG).
-  - **Field access override:** `getFieldValue($handle, $siteId = null)` throws `NotSupportedException` with message `"MockAsset does not support custom fields. Field '{$handle}' was requested. Use ->alt, ->title, or ->label on the builder, or pass a real Asset to this component."`
-  - **Explicit overrides for DB-touching methods** (`getVolume`, `getFolder`, `getFs`, `getUploader`, `getFieldLayout`, `getFieldValues`, `save`, `delete`, `validate`) — throw `NotSupportedException(__METHOD__ . ' is not supported on MockAsset; see README.')`. Per architecture review, don't try to enumerate every Element method exhaustively — focus on the ones that would query the DB if not stubbed.
+Every feature-bearing unit below carries `Execution note: test-first` — write the failing Codeception test that encodes the unit's acceptance behavior, watch it fail, then implement to green. Do **not** expand units into literal RED/GREEN/REFACTOR substeps. Static analysis (`composer check-cs && composer phpstan`) must be clean before a unit is considered done.
 
-- [ ] **`MockAssetBuilder` rewrite** (`src/models/MockAssetBuilder.php`):
-  - **Holds config array, not a MockAsset instance.** `private array $_config = [];` Constructs the `MockAsset` only in `one()` via `new MockAsset($this->_config)`. No more mid-chain half-built Asset.
-  - `configure(array $config): self` — merges into `$this->_config`. Unknown keys throw `InvalidArgumentException("Unknown mock asset config key: '{$key}'")`.
-  - Fluent setters: `width(int)`, `height(int)`, `label(string)`, `alt(string)`, `title(string)`, `filename(string)`, `focalPoint(array)`. Each writes to `$this->_config` and returns `$this`.
-  - `label(string $value)`: `trim($value)`; reject `if (strlen($value) > 200) throw new InvalidArgumentException('Mock label exceeds 200 characters.');` (security: bounds `queryFontMetrics` cost).
-  - `one(): MockAsset` — applies defaults (width=800, height=600 if unset; focalPoint stays null) then constructs `new MockAsset($this->_config)`.
+---
 
-- [ ] **`Assets` service extension** (`src/services/Assets.php`):
-  - `make(array $config = []): MockAssetBuilder` — wraps `(new MockAssetBuilder())->configure($config)` when config provided, else returns empty builder.
-  - Boot-time Imagick check inside `make()`: `if (!extension_loaded('imagick')) throw new RuntimeException('The Imagick PHP extension is required for parts-kit mock assets. Install ext-imagick or remove parts-kit mock usage.')`
-  - `signedUrlForImage(int $w, int $h, ?string $label): string` — single source of truth for routing **and** signing. Builds the canonical **keyed** payload (`Json::encode(['w' => $w, 'h' => $h, 'label' => $label])`), signs it with `Craft::$app->getSecurity()->hashData($payload)` (HMAC keyed by the app security key — the same primitive behind Craft's `|hash` Twig filter), URL-safe-encodes the result, and wraps it: `UrlHelper::siteUrl($partsKitDir . '/mock/' . StringHelper::base64UrlEncode($signed) . '.png')`. `MockAsset::getUrl()` delegates here.
-    - Use `yii\helpers\StringHelper::base64UrlEncode()` / `base64UrlDecode()` for transport-safe encoding of the signed payload (avoids `/`, `+`, `=` in the path segment). The controller reverses this before `validateData()`.
+## Implementation Units
 
-- [ ] **`MockController`** (`src/controllers/MockController.php`):
-  - Namespace: `viget\partskit\controllers`
-  - Extends `craft\web\Controller`
-  - `protected array|bool|int $allowAnonymous = ['view'];` (access decisions happen inside the action, mirroring the Parts Kit gate)
-  - `actionView(string $token): Response`:
-    1. **Access mirrors Parts Kit visibility (before signature validation — removes timing oracle):** if `Plugin::getInstance()->getSettings()->requireViewPermission` → `$this->requirePermission('parts-kit:view')`. **No devMode/admin hard-block** — if a user can view the Parts Kit, they can load its mock images. When `requireViewPermission` is `false`, `allowAnonymous` leaves the route public, exactly like the Parts Kit itself.
-    2. **Validate the signature (tamper-proof):** `$payload = Craft::$app->getSecurity()->validateData(StringHelper::base64UrlDecode($token)); if ($payload === false) throw new NotFoundHttpException();` — the HMAC is keyed by the app security key, so a tampered or hand-crafted token can't be forged and resolves to a standard 404 (no XSS risk; Craft renders its own error page).
-    3. **Decode the validated config:** `$config = Json::decode($payload);` then read `$config['w']`, `$config['h']`, `$config['label']`. These values are trusted — they came from a signature the server itself produced. New payload keys (e.g. `format`) are read here.
-    4. Resolve path: `$path = Craft::getAlias('@storage/runtime/parts-kit-mocks/') . sha1($payload) . '.png';` — the filename is derived from server-validated data, never from raw request input, so path traversal is structurally impossible (`basename()` is no longer needed).
-    5. **Generate on first request (fully lazy):** `if (!file_exists($path)) MockImageGenerator::generate($path, $config['w'], $config['h'], $config['label']);` — this is the **only** place images are generated. The first request for a URL creates the PNG; every later request (and any request after `clear-caches/all`) hits the cache or regenerates from the same signed config. No render-time generation, no sidecar files, no 404-then-refresh.
-    6. Set headers: `Cache-Control: public, max-age=31536000, immutable`. **No ETag, no 304 logic** — `immutable` is sufficient; the syscall and conditional-request branching are wasted complexity.
-    7. `return $this->response->sendFile($path, 'mock.png', ['mimeType' => 'image/png', 'inline' => true]);` — hardcoded `'mock.png'` for the disposition filename (defense in depth against future header-injection via filename interpolation)
+Units carry stable U-IDs and are grouped into the original four phases. Phases 1–4 map to PRs in order; within a phase, follow the dependency order.
 
-- [ ] **`Plugin.php` modifications**:
-  - In `_registerUrlRules()`: add `$event->rules[$partsKitDir . '/mock/<token:[A-Za-z0-9_-]+>\.png'] = 'parts-kit/mock/view';` — the segment is a URL-safe base64 signed token, not a bare hash.
-  - In `attachEventHandlers()`: register `ClearCaches::EVENT_REGISTER_CACHE_OPTIONS` listener:
-    ```php
-    Event::on(ClearCaches::class, ClearCaches::EVENT_REGISTER_CACHE_OPTIONS,
-      function (RegisterCacheOptionsEvent $event) {
-        $event->options[] = [
-          'key' => 'parts-kit-mocks',
-          'label' => Craft::t('parts-kit', 'Parts Kit mock images'),
-          'action' => Craft::getAlias('@storage/runtime/parts-kit-mocks'),
-        ];
-      });
-    ```
-  - **Note:** No per-render devMode warning is added. Abuse safety is enforced by the controller: access mirrors the Parts Kit gate, and the tamper-proof signed token means only server-issued URLs ever resolve (no forged dimensions/labels). Mocks are documented as Parts Kit-only and not a production asset substitute.
+### Phase 1 — Foundation scaffolding (separate PR)
 
-**Success criteria:** All functional acceptance criteria pass; static analysis clean; existing parts-kit functionality unchanged.
+A small, mergeable-on-its-own PR establishing the `Assets` service seam and the component-getter convention. Reframed from the original "cleanup" framing because **no WIP code exists to fix** — this is greenfield scaffolding that lets Phase 2 build on a registered service.
 
-#### Phase 3: Imager X integration
+#### U1. `Assets` service skeleton + Plugin wiring
 
-Soft-dependency on Imager X. Pro license enables full transparent integration; Lite gets a documented manual workaround in README. Integration is extracted into its own service per architecture review.
+**Goal:** A registered `assets` component reachable as `Plugin::getInstance()->getAssets()` and as the `partsKit.assets` Twig accessor, plus the typed-getter/`@property-read` convention applied to every component.
 
-**Tasks**
+**Requirements:** Prerequisite for AC1, AC3 (the `make()` entry point lands here as a stub returning a builder; full behavior in U5).
 
-- [ ] **`MockTransformedImage` model** (`src/models/MockTransformedImage.php`):
-  - Implements `spacecatninja\imagerx\models\TransformedImageInterface`
-  - Mirror `NoopImageModel` structure (`vendor/spacecatninja/imager-x/src/models/NoopImageModel.php` in projects that have Imager X installed — fall back to interface contract if not locally available)
-  - Constructor accepts `MockAsset $asset, array $transform`
-  - Methods return: `getUrl()` → `$asset->getUrl($transform)`, `getWidth()` and `getHeight()` → resolved via our own `Image::targetDimensions()`, `getPath()` → the disk path, `getExtension()` → 'png', `getMimeType()` → 'image/png'
-  - **Class file must remain loadable even if Imager X is absent.** Use guarded loading via Composer autoloader plus `class_exists` check in `ImagerXIntegration::register()` before any reference. No top-level `use` of Imager X types in `Plugin.php`.
+**Dependencies:** none.
 
-- [ ] **`ImagerXIntegration` service** (`src/services/ImagerXIntegration.php`):
-  - Extends `yii\base\Component`
-  - Static `isAvailable(): bool` → `class_exists(\spacecatninja\imagerx\services\ImagerService::class)`
-  - `register(): void` — call from `Plugin::init`. Attaches `EVENT_BEFORE_TRANSFORM_IMAGE` listener:
-    ```php
-    public function register(): void
-    {
-        if (!self::isAvailable()) {
-            return;
-        }
-        Event::on(
-            \spacecatninja\imagerx\services\ImagerService::class,
-            \spacecatninja\imagerx\services\ImagerService::EVENT_BEFORE_TRANSFORM_IMAGE,
-            $this->_handleBeforeTransform(...)
-        );
-    }
+**Files:** `src/services/Assets.php` (new, minimal), `src/Plugin.php` (modify), `tests/unit/PluginWiringTest.php` (new), `tests/unit/services/AssetsTest.php` (new — stub-level only).
 
-    private function _handleBeforeTransform(\spacecatninja\imagerx\events\TransformImageEvent $event): void
-    {
-        if (!$event->image instanceof MockAsset) {
-            return;
-        }
-        $event->transformedImages = array_map(
-            fn(array $t) => new MockTransformedImage($event->image, $t),
-            $event->transforms
-        );
-    }
-    ```
+**Approach:** Mirror the existing `Navigation` registration exactly: add `'assets' => Assets::class` to `config()['components']`, add `getAssets(): Assets` returning `$this->get('assets')`, add `@property-read Assets $assets` to the class docblock, and audit `getNavigation()` for a matching `@property-read Navigation $navigation` (add if missing). Establish the convention in a one-line comment: every component in `config()['components']` gets a typed getter AND a `@property-read` line. `Assets` is a `craft\base\Component` for now with a placeholder `make()` signature.
 
-- [ ] **`Plugin::config()`** — register the new service:
-  ```php
-  'components' => [
-      'navigation' => Navigation::class,
-      'assets' => Assets::class,
-      'imagerXIntegration' => ImagerXIntegration::class,
-  ],
-  ```
+**Patterns to follow:** `src/services/Navigation.php` (component shape), `src/Plugin.php` `getNavigation()` (getter), `tests/unit/services/NavigationTest.php` (unit-test style — instantiate the service, assert behavior).
 
-- [ ] **`Plugin::init()`** — call `$this->get('imagerXIntegration')->register();` after `attachEventHandlers()`. (Service handles the `isAvailable()` guard internally.)
+**Execution note:** test-first.
 
-- [ ] **No Lite-license boot detection.** Document the manual `{ noop: true }` workaround in README. Don't add runtime detection — Viget uses Pro, and the warning would be noise for the 0.1% Lite case.
+**Test scenarios:**
+- `PluginWiringTest::testAssetsComponentIsRegistered` — `Plugin::getInstance()->getAssets()` returns an `Assets` instance (not null, correct type).
+- `PluginWiringTest::testNavigationGetterStillResolves` — guard against regressing the existing getter while adding the convention.
+- `PluginWiringTest::testPartsKitTwigVariableExposesAssets` — the `partsKit` CraftVariable resolves `.assets` to the service (asserts the Twig-facing seam used by `make`).
+- `AssetsTest::testMakeReturnsBuilder` — `make()` returns a `MockAssetBuilder` (will be a thin stub until U3/U5; this test is updated, not rewritten, in U5).
 
-**Success criteria:** AC8 passes; non-Imager-X projects unaffected (plugin boots cleanly without Imager X installed); README documents the Lite workaround.
+**Verification:** `composer test-unit` green; `composer check-cs && composer phpstan` clean; `getAssets()` resolves at runtime.
 
-#### Phase 4: Polish & docs
+---
 
-**Tasks**
+### Phase 2 — Core mock implementation
 
-- [ ] **README.md updates**:
-  - New section "Mock Assets" with the Twig usage examples from this plan
-  - Document the supported `Asset` surface (and what throws)
-  - Document Imager X Pro vs Lite behavior, including the manual `{ noop: true }` workaround for Lite
-  - Note: mock image access mirrors Parts Kit visibility — public when `requireViewPermission` is off, otherwise gated on `parts-kit:view`. URLs are HMAC-signed and tamper-proof; an altered token returns `404`. Mocks are intended for Parts Kit templates only, not as a production asset substitute.
-  - Note: cache wipes with `php craft clear-caches/all`
-  - Note: file proliferation — different labels create different cached PNGs; cap is 5,000 files per directory
-- [ ] Verify all `NotSupportedException` messages name the unsupported method and point to README
-- [ ] **Audit one or two Viget consumer projects** for `Asset $param` type-hints in components. Confirm the extends-Asset path works for typed code. Document any patterns where components are untyped so v2 can consider an interface-based alternative.
-- [ ] Test in CP entry preview context to verify mock URLs work outside the parts-kit iframe
-- [ ] Final pass: `composer check-cs && composer phpstan`
+The meat. Feature dependencies (U2) land first, then the builder/element/service/generator/controller in dependency order.
 
-**Success criteria:** README documents the full API; CP preview context verified; CI green; consumer-project audit recorded in the PR description.
+#### U2. Feature dependencies — `ext-imagick`, bundled font
 
-## Alternative Approaches Considered
+**Goal:** Declare the Imagick requirement and ship the fallback font so generation works on slim images.
 
-These were evaluated in the brainstorm and explicitly rejected:
+**Requirements:** Prerequisite for U7 (generation) and AC2.
 
-- **Base64 data URLs:** bloats HTML, defeats browser caching, can't run Craft transforms.
-- **Pre-generation + real Craft transform pipeline:** requires auto-provisioning a real Volume and creating DB rows per unique size. Crosses the line from "mock" into "real ephemeral asset"; the user explicitly preferred no DB writes.
-- **External placeholder service (placehold.co, picsum):** requires internet, no transform support, third-party dependency.
-- **Imager X custom Transformer registration:** Pro-only, requires authors to opt in via `transformer: 'mock'` per call. `EVENT_BEFORE_TRANSFORM_IMAGE` does it transparently based on asset type.
-- **Sidecar `{hash}.json` config files for URL durability:** unnecessary — the tamper-proof signed token already carries the (HMAC-validated) config, so the controller regenerates a cleared PNG on demand without any sidecar file. Durability comes for free from the signing scheme.
-- **GD fallback when Imagick is missing:** YAGNI. Imagick is already a Craft transform dependency in most production stacks; we add it as a composer requirement.
+**Dependencies:** none (can land alongside U1).
+
+**Files:** `composer.json` (add `"ext-imagick": "*"` to `require`), `src/resources/fonts/DejaVuSans.ttf` (new binary).
+
+**Approach:** Add the extension constraint to `require`. Add the TTF under `src/resources/fonts/` — covered by the existing PSR-4-adjacent package contents (verify it is **not** matched by any `export-ignore` rule in `.gitattributes`, since `docs/`, `craft-install/`, `.ddev/` are stripped from the dist package). **No CI workflow change is needed** — `imagick` is already in `PHP_EXTENSIONS` in both `.github/workflows/ci.yml` and `codecept.yml`.
+
+**Patterns to follow:** existing `composer.json` `require` block.
+
+**Execution note:** none — config/asset scaffolding.
+
+**Test scenarios:** `Test expectation: none — dependency/asset declaration.` Verification is `composer validate` succeeds, the font file is present and committed, and `git archive` (per `.github/workflows/package-contents.yml`) still includes `src/resources/fonts/DejaVuSans.ttf`.
+
+**Verification:** `composer validate`; confirm font ships in the package archive; CI install step succeeds with the new constraint.
+
+#### U3. `MockAssetBuilder`
+
+**Goal:** A fluent + array-config builder that accumulates config and constructs a `MockAsset` only in `one()`.
+
+**Requirements:** AC3 (defaults), AC6/AC7 (config drives identity downstream), NFR7 (label cap).
+
+**Dependencies:** U1.
+
+**Files:** `src/models/MockAssetBuilder.php` (new), `tests/unit/models/MockAssetBuilderTest.php` (new).
+
+**Approach:** `private array $_config = []`. `configure(array): self` merges and throws `InvalidArgumentException` on unknown keys. Fluent setters `width/height/label/alt/title/filename/focalPoint` each write to `_config` and return `$this`. `label()` trims and rejects > 200 chars. `one(): MockAsset` applies defaults (width 800, height 600 if unset; focalPoint null) and returns `new MockAsset($this->_config)`. The builder does **not** touch a `MockAsset` until `one()`.
+
+**Patterns to follow:** Yii `new X($config)` idiom; existing model conventions in `src/models/`.
+
+**Execution note:** test-first.
+
+**Test scenarios:**
+- `testFluentSettersAccumulateConfig` — chained setters produce a `MockAsset` with the expected width/height/label/alt.
+- `testConfigureMergesArray` — `configure(['width' => 400])` then `one()` reflects the value.
+- `testUnknownConfigKeyThrows` — `configure(['bogus' => 1])` throws `InvalidArgumentException` naming the key.
+- `testDefaultsAppliedWhenUnset` — Covers AE/AC3. `(new MockAssetBuilder())->one()` yields width 800, height 600.
+- `testLabelOver200CharsThrows` — Covers NFR7. 201-char label → `InvalidArgumentException`.
+- `testLabelIsTrimmed` — `'  Hero  '` becomes `'Hero'`.
+- `testOneReturnsFreshInstances` — two `one()` calls return distinct objects (no shared mutable state across chains).
+
+**Verification:** `composer test-unit` green for the builder class; static analysis clean.
+
+#### U4. `MockAsset` — surface, dimensions, unsupported guards
+
+**Goal:** The element's non-URL surface: construction/init defaults, metadata getters/setters, mode-aware dimension resolution, and `NotSupportedException` for DB-touching methods. (URL emission is U6.)
+
+**Requirements:** AC5 (dimension math), AC10 (unsupported throws); supports AC4.
+
+**Dependencies:** U3.
+
+**Files:** `src/models/MockAsset.php` (new), `tests/unit/models/MockAssetTest.php` (new).
+
+**Approach:** Extend `craft\elements\Asset`. Class docblock states the LSP-violation contract verbatim (see Enhancement item 14). `__construct($config = [])` → `parent::__construct($config)`; `init()` → `parent::init()` then defaults `id = -1`, `kind = Asset::KIND_IMAGE`, `setScenario(self::SCENARIO_CREATE)`. Private typed props `?int $_width/$_height`, `?string $_label/$_filename`, `?array $_focalPoint`; `alt`/`title` inherited. Override `getWidth(array|string|ImageTransform $transform = null): ?int` (typed union, **not** `mixed` — LSP) and `getHeight(...)`: normalize via `ImageTransforms::normalizeTransform()`, then `Image::targetDimensions(...)` for mode-aware sizing. Metadata: `getFilename/setFilename/getExtension/getMimeType/getHasFocalPoint/getFocalPoint/setFocalPoint`; default filename `mock-{w}x{h}.png`, derive ext/mime from a set filename, `kind` stays image. `getFieldValue()` and DB-touching methods (`getVolume/getFolder/getFs/getUploader/getFieldLayout/getFieldValues/save/delete/validate`) throw `NotSupportedException(__METHOD__ . ' is not supported on MockAsset; see README.')`.
+
+**Patterns to follow:** Craft 5 `craft\elements\Asset` signatures (`getWidth()` typed union at `Asset.php:2509`); `ImageTransforms::normalizeTransform()` (`ImageTransforms.php:270`); `Image::targetDimensions()` (`Image.php:90`).
+
+**Technical design (directional, not spec):** dimension resolution = normalize transform → `Image::targetDimensions($this->_width, $this->_height, $t->width, $t->height, $t->mode, $t->upscale)`. A placeholder has no subject, so crop/fit/stretch/letterbox differ only in resulting dimensions.
+
+**Execution note:** test-first. Use array/`ImageTransform` transforms in tests, not named handles (see Testing Strategy).
+
+**Test scenarios:**
+- `testConstructWithConfigSetsDimensions` — `new MockAsset(['width' => 800, 'height' => 600])` reports those base dims (no transform).
+- `testInitDefaults` — fresh instance has `kind === Asset::KIND_IMAGE` and `id === -1`.
+- `testGetWidthHeightNoTransform` — returns base dims.
+- `testGetWidthFitTransformAspectPreserved` — Covers AC5. base 1600×900, `['width' => 400, 'mode' => 'fit']` → width 400, height 225.
+- `testGetWidthStretchVsFitDiffer` — same inputs, `stretch` vs `fit` produce the documented different dimensions (mode-awareness).
+- `testDefaultFilenameDerivedFromDimensions` — default filename is `mock-800x600.png`; extension `png`, mimeType `image/png`.
+- `testSetFilenameDerivesExtensionAndMime` — `setFilename('hero.jpg')` → extension `jpg`, mimeType `image/jpeg`.
+- `testFocalPointDefaultsToNullAndHasFocalPointFalse` — `getHasFocalPoint()` false, `getFocalPoint()` null by default.
+- `testUnsupportedMethodThrowsWithMethodNameAndReadme` — Covers AC10. `getVolume()`/`getFieldValue('caption')` throw `NotSupportedException`; message contains the method name AND `README`.
+
+**Verification:** `composer test-unit` green; static analysis clean (PHPStan must accept the typed-union override).
+
+#### U5. `Assets::make()` + `signedUrlForImage()` + Imagick boot check
+
+**Goal:** The single source of truth for routing and HMAC signing, plus the public `make()` entry and the boot-time Imagick guard.
+
+**Requirements:** AC1 (URL pattern), AC6/AC7 (hash identity), NFR2 (tamper-proof), NFR4 (Imagick missing).
+
+**Dependencies:** U1, U3.
+
+**Files:** `src/services/Assets.php` (expand), `tests/unit/services/AssetsTest.php` (expand from U1 stub).
+
+**Approach:** `make(array $config = []): MockAssetBuilder` wraps `(new MockAssetBuilder())->configure($config)` when config is provided, else an empty builder; it runs the Imagick check (`if (!extension_loaded('imagick')) throw new RuntimeException(...)` naming the extension + README). `signedUrlForImage(int $w, int $h, ?string $label): string` builds the keyed payload `Json::encode(['w' => $w, 'h' => $h, 'label' => $label], JSON_THROW_ON_ERROR)`, signs with `Craft::$app->getSecurity()->hashData($payload)`, `base64UrlEncode`s it, and wraps with `UrlHelper::siteUrl($partsKitDir . '/mock/' . $token . '.png')`. The on-disk filename is `sha1($payload)` (computed by the controller, not here).
+
+**Patterns to follow:** `yii\helpers\StringHelper::base64UrlEncode/Decode`; Craft `Security::hashData/validateData`; the `|hash` Twig filter primitive.
+
+**Execution note:** test-first.
+
+**Test scenarios:**
+- `testMakeReturnsConfiguredBuilder` — `make(['width' => 400])->one()` reports width 400.
+- `testMakeNoArgsReturnsEmptyBuilder` — `make()->one()` yields defaults.
+- `testSignedUrlMatchesRoutePattern` — Covers AC1. URL matches `#/parts-kit/mock/[A-Za-z0-9_-]+\.png$#`.
+- `testSignedTokenRoundTrips` — decode the token, `Security::validateData()` returns the original payload; decoded `['w','h','label']` match inputs (NFR2 positive).
+- `testTamperedTokenFailsValidation` — flip one byte of the token → `validateData()` returns false (NFR2 negative; the crypto half of AC13, asserted without HTTP).
+- `testIdenticalConfigProducesIdenticalUrlAndHash` — Covers AC6. same `(w,h,label)` → identical URL and identical `sha1($payload)`.
+- `testDifferentLabelProducesDifferentHash` — Covers AC7. label `'Hero'` vs `'Thumbnail'` → different token and different `sha1`.
+- `testKeyedPayloadIsOrderStable` — payload encodes keys deterministically so the hash is stable across calls.
+- *(NFR4)* — assert the `make()` Imagick guard throws `RuntimeException` with the extension name; since `imagick` is always loaded in CI, document this as a guard-shape assertion / manual check per Testing Strategy rather than forcing a brittle extension-unload mock.
+
+**Verification:** `composer test-unit` green; round-trip and tamper assertions pass deterministically against the fixed `SECURITY_KEY`.
+
+#### U6. `MockAsset` transform-emitting methods (render-time, no generation)
+
+**Goal:** `getUrl/getImg/getSrcset/getUrlsBySize` emit signed URL strings only — memoized, zero Imagick, zero filesystem.
+
+**Requirements:** AC1, AC4 (img markup), AC11 (zero render-time generation), AC12 (srcset emits N URLs lazily).
+
+**Dependencies:** U4, U5.
+
+**Files:** `src/models/MockAsset.php` (expand), `tests/unit/models/MockAssetTest.php` (expand).
+
+**Approach:** `private array $_urlCache = []` keyed by normalized transform args. `getUrl(mixed $transform = null, ?bool $immediately = null): ?string` — normalize, resolve to final w/h, delegate to `getAssets()->signedUrlForImage($w, $h, $this->_label)`, memoize. `getImg(mixed $transform = null, ?array $sizes = null): ?Markup` — mirror Craft's `Html::tag('img', ...)` with `src/width/height/srcset/alt`; null when `kind !== KIND_IMAGE`. `getSrcset(array $sizes, mixed $transform = null): string|false` — compose from per-size signed URLs. `getUrlsBySize(array $sizes, mixed $transform = null): array`.
+
+**Patterns to follow:** Craft `Asset::getImg()` (`Asset.php:1832`), `getSrcset()` (`1888`), `getUrl()` (`2150`).
+
+**Execution note:** test-first. AC11/AC12 are the headline guarantees — assert no file is touched and Imagick is never constructed during render.
+
+**Test scenarios:**
+- `testGetUrlEmitsSignedUrl` — Covers AC1. `getUrl()` matches the route pattern.
+- `testGetUrlIsMemoized` — two identical `getUrl()` calls return the identical string (and, if observable, sign once).
+- `testGetUrlWithTransformResolvesDimensions` — `getUrl(['width' => 400, 'mode' => 'fit'])` encodes 400×225 in the payload.
+- `testGetImgMarkup` — Covers AC4. `make({width:800,height:600,alt:'Hero'}).one.getImg()` renders `<img>` with `src`, `width="800"`, `height="600"`, `alt="Hero"`.
+- `testGetImgReturnsNullForNonImageKind` — when `kind` is forced non-image, `getImg()` is null (Craft parity).
+- `testGetSrcsetReturnsNUrls` — Covers AC12. `getSrcset(['1x','2x'])` (or width list) yields N distinct signed URLs.
+- `testRenderTouchesNoFilesystemAndNoImagick` — Covers AC11. wrap a render of `getUrl/getImg/getSrcset` and assert the mocks cache dir gains zero files and no `Imagick` instance is created (assert via a temp dir snapshot before/after).
+
+**Verification:** `composer test-unit` green; AC11 file-count snapshot is exactly zero; static analysis clean.
+
+#### U7. `MockImageGenerator` helper
+
+**Goal:** The only PNG generation path — produces correctly-sized PNGs with centered scaled text, written atomically, bounded by a file-count cap.
+
+**Requirements:** AC2 (exact pixel dims), NFR1 (atomic write), NFR6 (5,000-file cap).
+
+**Dependencies:** U2.
+
+**Files:** `src/helpers/MockImageGenerator.php` (new, first occupant of `helpers/`), `tests/unit/helpers/MockImageGeneratorTest.php` (new).
+
+**Approach:** Static `generate(string $path, int $width, int $height, ?string $label): void`. Font chain: bundled `DejaVuSans.ttf` → `/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf` → `/System/Library/Fonts/Helvetica.ttc` → `RuntimeException` with install hint. Render bg `#999999`, centered white label (default `"{w}x{h}"`). Scale-to-fit: start `(int)(min($w,$h) * 0.2)`, step down via `queryFontMetrics()` until fit, floor 8px. PNG: `setImageFormat('png')`, quality 75, `stripImage()`. Atomic write: temp file `$path.tmp.{bin2hex(random_bytes(8))}` then `rename()`. Before writing, count `*.png`; if > 5,000, `Craft::warning(...)` and abort (caller treats a missing file as a normal miss). No try/catch — let Imagick exceptions bubble.
+
+**Patterns to follow:** Imagick `setFont`/`queryFontMetrics` docs; stateless static helper (class docblock explains the namespace + testability rationale).
+
+**Execution note:** test-first — this is the unit where TDD pays off most, since the static helper is directly callable with a temp path.
+
+**Test scenarios:**
+- `testGeneratesPngOfExactDimensions` — Covers AC2. `generate($tmp, 800, 600, null)` → `getimagesize()` returns 800×600 and PNG mime.
+- `testGeneratesPngWithCustomLabel` — non-default label produces a valid PNG of the requested dims (text path doesn't throw).
+- `testDefaultLabelIsDimensions` — with null label the file is produced (smoke: valid PNG); optional visual check deferred.
+- `testOutputIsValidPngSignature` — first bytes match the PNG magic number.
+- `testAtomicWriteLeavesNoTempFile` — Covers NFR1. after `generate()`, the final path exists and no `*.tmp.*` sibling remains.
+- `testFileCountCapAbortsGeneration` — Covers NFR6. pre-seed the dir with 5,001 `*.png` stubs; `generate()` logs a warning and does **not** create the target file.
+- `testMissingFontChainThrowsRuntimeException` — when no font resolves (simulate by pointing the chain at a temp dir with no font), `RuntimeException` with an install hint. *(If the bundled font always resolves, cover this as a guard-shape assertion.)*
+- *(small dims)* `testSmallDimensionsFloorFontAt8px` — `generate($tmp, 10, 10, '10x10')` succeeds (font floor prevents a zero/negative point size).
+
+**Verification:** `composer test-unit` green (requires `imagick` — present in CI); generated files asserted via `getimagesize()`; temp dir cleaned in `_after`.
+
+#### U8. `MockController` + URL rule
+
+**Goal:** The HTTP endpoint: Parts Kit gate → HMAC validation → lazy generation → `sendFile`, addressed by the signed-token route.
+
+**Requirements:** AC2 (200 + headers + dims), AC12 (cold-cache lazy gen), AC13 (tamper 404 + visibility), NFR3 (visibility mirror), NFR8 (gate before validation).
+
+**Dependencies:** U5, U6, U7.
+
+**Files:** `src/controllers/MockController.php` (new), `src/Plugin.php` (add URL rule), `tests/functional/MockControllerCest.php` (new).
+
+**Approach:** Namespace `viget\partskit\controllers`, extends `craft\web\Controller`, `protected array|bool|int $allowAnonymous = ['view'];`. `actionView(string $token): Response`: (1) if `getSettings()->requireViewPermission` → `requirePermission('parts-kit:view')` **before** any token work; (2) `validateData(base64UrlDecode($token))` → false ⇒ `NotFoundHttpException`; (3) `Json::decode($payload)` → read `w/h/label`; (4) `$path = Craft::getAlias('@storage/runtime/parts-kit-mocks/') . sha1($payload) . '.png'`; (5) `if (!file_exists($path)) MockImageGenerator::generate(...)` — the **only** generation site; (6) headers `Cache-Control: public, max-age=31536000, immutable`; (7) `return $this->response->sendFile($path, 'mock.png', ['mimeType' => 'image/png', 'inline' => true])`. URL rule in `_registerUrlRules()`: `$event->rules[$partsKitDir . '/mock/<token:[A-Za-z0-9_-]+>\.png'] = 'parts-kit/mock/view';`.
+
+**Patterns to follow:** `src/controllers/ViewController.php` (`allowAnonymous`, action shape), `tests/functional/PartsKitRouteCest.php` (functional route + permission-gate assertions, `amLoggedInAs`).
+
+**Execution note:** test-first via the functional suite. Generate a valid token in-test by calling `Assets::signedUrlForImage()` and extracting the path segment, then `$I->amOnPage()` it.
+
+**Test scenarios (functional `Cest`):**
+- `validTokenReturns200PngOfExactDimensions` — Covers AC2. with `requireViewPermission=false` (or logged-in admin), GET a signed 800×600 URL → 200, `Content-Type: image/png`, `Cache-Control: public, max-age=31536000, immutable`, body is an 800×600 PNG (assert via `getimagesizefromstring()` on the response body).
+- `coldCacheGeneratesThenServes` — Covers AC12. clear the mocks dir, request a fresh URL → 200 and the file now exists on disk; a second request still 200 (cache hit).
+- `tamperedTokenReturns404` — Covers AC13. mutate one byte of a valid token → 404 (`NotFoundHttpException`).
+- `anonymousDeniedWhenPermissionRequired` — Covers NFR3. `requireViewPermission=true`, no user → 403 (mirror `PartsKitRouteCest`'s gate assertion).
+- `adminAllowedWhenPermissionRequired` — `requireViewPermission=true`, admin logged in → 200.
+- `publicWhenPermissionNotRequired` — `requireViewPermission=false`, anonymous → 200.
+- `gateRunsBeforeValidation` — Covers NFR8. `requireViewPermission=true`, anonymous, **tampered** token → 403 (not 404), proving no token oracle.
+- `differentLabelsServeSeparateFiles` — Covers AC7 end-to-end. two URLs differing only by label produce two files on disk.
+
+**Verification:** `composer test-functional` green; response-body PNG dimensions asserted; 403-before-404 ordering proven.
+
+#### U9. ClearCaches integration
+
+**Goal:** `php craft clear-caches/all` empties `@storage/runtime/parts-kit-mocks/`.
+
+**Requirements:** AC9.
+
+**Dependencies:** U8.
+
+**Files:** `src/Plugin.php` (register `ClearCaches::EVENT_REGISTER_CACHE_OPTIONS`), `tests/unit/PluginWiringTest.php` (expand).
+
+**Approach:** In `attachEventHandlers()`, register a `RegisterCacheOptionsEvent` listener pushing `['key' => 'parts-kit-mocks', 'label' => Craft::t('parts-kit', 'Parts Kit mock images'), 'action' => Craft::getAlias('@storage/runtime/parts-kit-mocks')]`.
+
+**Patterns to follow:** `ClearCaches::EVENT_REGISTER_CACHE_OPTIONS` (`ClearCaches.php:42`); existing `Event::on` registrations in `attachEventHandlers()`.
+
+**Execution note:** test-first.
+
+**Test scenarios:**
+- `testCacheOptionRegistered` — trigger `ClearCaches::EVENT_REGISTER_CACHE_OPTIONS` (or read `Craft::$app->utilities` cache options) and assert an option with key `parts-kit-mocks` whose `action` path resolves to the mocks dir.
+- `testClearCachesEmptiesMocksDir` — Covers AC9. seed a PNG in the mocks dir, invoke the registered `action`/clear path, assert the directory is empty afterward.
+
+**Verification:** `composer test-unit` green; before/after directory listing confirms emptied.
+
+---
+
+### Phase 3 — Imager X integration
+
+Soft dependency. Pro enables transparent integration; Lite gets a documented manual workaround. The class files must load even when Imager X is absent, and the tests must skip themselves when it is.
+
+#### U10. `MockTransformedImage` model
+
+**Goal:** A `TransformedImageInterface` implementation that points back at the `MockAsset`'s signed URL.
+
+**Requirements:** AC8 (Imager X result), NFR5 (loads without Imager X).
+
+**Dependencies:** U6.
+
+**Files:** `src/models/MockTransformedImage.php` (new), `tests/unit/models/MockTransformedImageTest.php` (new).
+
+**Approach:** Implements `spacecatninja\imagerx\models\TransformedImageInterface`, mirroring `NoopImageModel`. Constructor `(MockAsset $asset, array $transform)`. `getUrl()` → `$asset->getUrl($transform)`; `getWidth/getHeight` → resolved via `Image::targetDimensions()`; `getPath()` → disk path; `getExtension()` → `'png'`; `getMimeType()` → `'image/png'`. The class must remain loadable with Imager X absent — autoload only, guarded by `class_exists` checks at registration (U11), no top-level `use` of Imager X types in `Plugin.php`.
+
+**Patterns to follow:** `spacecatninja/imager-x/src/models/NoopImageModel.php` (fall back to the interface contract if Imager X isn't installed locally).
+
+**Execution note:** test-first, but the test **skips** when `ImagerXIntegration::isAvailable()` is false.
+
+**Test scenarios:**
+- `testUrlDelegatesToAsset` — *(skipped unless Imager X present)* `getUrl()` equals `$asset->getUrl($transform)`.
+- `testWidthHeightResolveViaTargetDimensions` — *(skipped unless present)* dims match the transform.
+- `testExtensionAndMimeArePng` — *(skipped unless present)* `'png'` / `'image/png'`.
+- `Test note:` all cases call `$this->markTestSkipped('Imager X not installed')` when the interface is absent — this is the auto-tested expression of "loads/behaves only when available."
+
+**Verification:** `composer test-unit` green (tests skip cleanly when Imager X absent); class autoloads without fatal when Imager X is not installed.
+
+#### U11. `ImagerXIntegration` service + registration
+
+**Goal:** Conditionally attach the `EVENT_BEFORE_TRANSFORM_IMAGE` listener that swaps in `MockTransformedImage` for `MockAsset` inputs.
+
+**Requirements:** AC8, NFR5.
+
+**Dependencies:** U10.
+
+**Files:** `src/services/ImagerXIntegration.php` (new), `src/Plugin.php` (register component + call `register()`), `tests/unit/services/ImagerXIntegrationTest.php` (new).
+
+**Approach:** Extends `yii\base\Component`. Static `isAvailable(): bool` → `class_exists(\spacecatninja\imagerx\services\ImagerService::class)`. `register(): void` returns early when unavailable, else `Event::on(ImagerService::class, EVENT_BEFORE_TRANSFORM_IMAGE, $this->_handleBeforeTransform(...))`. Handler: if `$event->image instanceof MockAsset`, set `$event->transformedImages = array_map(fn($t) => new MockTransformedImage($event->image, $t), $event->transforms)`. Register `'imagerXIntegration' => ImagerXIntegration::class` in `config()['components']` (with getter + `@property-read` per the U1 convention) and call `$this->get('imagerXIntegration')->register()` after `attachEventHandlers()` in `init()`.
+
+**Patterns to follow:** `Navigation`/`Assets` component registration; `ImagerService::EVENT_BEFORE_TRANSFORM_IMAGE` (`ImagerService.php:46`); `TransformImageEvent` payload shape.
+
+**Execution note:** test-first. The NFR5 guard test runs in CI (Imager X absent); AC8 is manual.
+
+**Test scenarios:**
+- `testIsAvailableFalseWithoutImagerX` — Covers NFR5. in CI (no Imager X), `isAvailable()` is false and `register()` is a no-op (no exception, plugin boots).
+- `testPluginBootsWithoutImagerX` — Covers NFR5. assert the plugin instance initializes and `imagerXIntegration` component resolves even though Imager X is absent.
+- `testListenerSwapsMockAsset` — *(skipped unless Imager X present)* Covers AC8. firing `EVENT_BEFORE_TRANSFORM_IMAGE` with a `MockAsset` populates `transformedImages` with `MockTransformedImage`s; with a non-mock it passes through unchanged.
+- **Manual AC8** — with Imager X Pro installed in the DDEV harness, `craft.imagerx.transformImage(mock, {width:400})` returns a `MockTransformedImage` serving a 400px PNG, and `LocalSourceImageModel::getLocalCopy()` is never invoked.
+
+**Verification:** `composer test-unit` green with Imager X absent (guard tests pass, integration tests skip); manual AC8 recorded in the PR.
+
+---
+
+### Phase 4 — Polish & docs
+
+#### U12. README, CHANGELOG, consumer audit, final checks
+
+**Goal:** Document the API and supported surface; verify CP preview context; record the consumer-project audit.
+
+**Requirements:** Documentation Plan; AC10 message audit; CP-preview risk row.
+
+**Dependencies:** U8, U11.
+
+**Files:** `README.md` (modify), `CHANGELOG.md` (modify).
+
+**Approach:** New "Mock Assets" README section with the Twig examples, the supported-`Asset`-surface table (and what throws), the Imager X Pro/Lite matrix incl. the manual `{ noop: true }` workaround, the visibility note (mirrors Parts Kit; HMAC-signed; tampered → 404; dev-only intent), the `clear-caches/all` note, and the file-proliferation/5,000-cap note. CHANGELOG entry announcing mock assets + the `ext-imagick` requirement. Verify every `NotSupportedException` message names the method and points to README. Audit one or two Viget consumer projects for `Asset $param` type-hints and record findings in the PR. Manually verify CP entry-preview context renders mock URLs.
+
+**Patterns to follow:** existing `README.md` structure; `craft-viget-base-testing-reference` for doc conventions.
+
+**Execution note:** none — docs and manual verification.
+
+**Test scenarios:** `Test expectation: none — documentation and manual verification.` The behavioral guarantees were locked by U1–U11's automated tests; this unit adds prose and the two manual checks (CP preview, consumer audit).
+
+**Verification:** `composer test && composer check-cs && composer phpstan` all green; README + CHANGELOG updated; CP-preview and consumer-audit results recorded in the PR description.
+
+---
 
 ## Acceptance Criteria
 
+Each criterion now names the test(s) that enforce it. "Manual" criteria are those the soft Imager X / Imagick-absent dependencies put out of CI reach (see Testing Strategy).
+
 ### Functional Requirements
 
-- [ ] **AC1** — `partsKit.assets.make({width: 800, height: 600}).one` returns a `MockAsset` whose `.getUrl()` returns a URL matching `/parts-kit/mock/[A-Za-z0-9_-]+\.png` (a URL-safe, HMAC-signed token).
-- [ ] **AC2** — A GET to the URL from AC1 by a requester who can view the Parts Kit returns HTTP 200, `Content-Type: image/png`, `Cache-Control: public, max-age=31536000, immutable`, and a PNG of exact pixel dimensions 800×600.
-- [ ] **AC3** — `partsKit.assets.make.one` (no setters) renders an 800×600 PNG (the default).
-- [ ] **AC4** — `partsKit.assets.make({width: 800, height: 600, alt: 'Hero'}).one.getImg()` renders `<img>` with `src`, `width=800`, `height=600`, `alt="Hero"` attributes populated.
-- [ ] **AC5** — `partsKit.assets.make({width: 1600, height: 900}).one.getUrl({width: 400, mode: 'fit'})` returns a URL that serves a 400×225 PNG (aspect-preserved via `Image::targetDimensions`).
-- [ ] **AC6** — Two identically-configured mocks produce the same hash, generate one file on disk, and return the same URL.
-- [ ] **AC7** — Changing only `label` (e.g. `{label: 'Hero'}` vs `{label: 'Thumbnail'}`) produces a different hash and a separate file on disk (this is intentional and documented).
-- [ ] **AC8** — With Imager X Pro installed, `craft.imagerx.transformImage(mock, {width: 400})` returns a `MockTransformedImage` whose URL serves a 400-px-wide PNG. `LocalSourceImageModel::getLocalCopy()` is never invoked.
-- [ ] **AC9** — `php craft clear-caches/all` empties `@storage/runtime/parts-kit-mocks/` (verified by listing the directory before and after).
-- [ ] **AC10** — Calling any unsupported `Asset` method (e.g. `mock.getVolume()`, `mock.getFolder()`, `mock.getFieldValue('caption')`) throws `NotSupportedException` whose message includes the method name AND a pointer to the README.
-- [ ] **AC11** — Template rendering performs zero image generation and zero filesystem access: `getUrl()`/`getImg()`/`getSrcset()` only build signed URL strings (verifiable by asserting Imagick is never instantiated and no file is touched during a render). All generation happens inside `MockController`.
-- [ ] **AC12** — A `getSrcset` call with N sizes triggers no generation at render time; it returns N signed URLs, and each size's PNG is generated lazily on its first HTTP request (then cached). Requesting all N URLs on a cold cache produces N correctly-sized PNGs.
-- [ ] **AC13** — A mock URL whose signed token has been altered by even one byte returns HTTP 404 via `Security::validateData()`. An untampered URL is viewable by exactly whoever can view the Parts Kit: public when `requireViewPermission = false`, gated on `parts-kit:view` when `true`. There is no separate devMode gate on mock images.
+- [ ] **AC1** — `make({width:800,height:600}).one.getUrl()` matches `/parts-kit/mock/[A-Za-z0-9_-]+\.png`. → `AssetsTest`, `MockAssetTest`.
+- [ ] **AC2** — GET that URL (as a Parts-Kit-viewer) → 200, `Content-Type: image/png`, `Cache-Control: public, max-age=31536000, immutable`, PNG exactly 800×600. → `MockControllerCest`, `MockImageGeneratorTest`.
+- [ ] **AC3** — `make.one` (no setters) → 800×600 default. → `MockAssetBuilderTest`.
+- [ ] **AC4** — `make({width:800,height:600,alt:'Hero'}).one.getImg()` → `<img>` with `src/width=800/height=600/alt="Hero"`. → `MockAssetTest`.
+- [ ] **AC5** — `make({width:1600,height:900}).one.getUrl({width:400,mode:'fit'})` serves 400×225. → `MockAssetTest` (dims) + `MockControllerCest` (served bytes).
+- [ ] **AC6** — Two identical configs → same hash, one file, same URL. → `AssetsTest`.
+- [ ] **AC7** — Changing only `label` → different hash + separate file. → `AssetsTest` (hash) + `MockControllerCest` (separate files).
+- [ ] **AC8** — *(Manual + skipped CI test)* Imager X Pro: `transformImage(mock,{width:400})` → `MockTransformedImage` serving a 400px PNG; `LocalSourceImageModel::getLocalCopy()` never invoked. → `ImagerXIntegrationTest` (skipped when absent) + manual DDEV check.
+- [ ] **AC9** — `clear-caches/all` empties the mocks dir. → `PluginWiringTest`.
+- [ ] **AC10** — Any unsupported method throws `NotSupportedException` naming the method + README. → `MockAssetTest`.
+- [ ] **AC11** — Render does zero generation/filesystem work. → `MockAssetTest` (file-count snapshot == 0, no Imagick instance).
+- [ ] **AC12** — `getSrcset` with N sizes emits N URLs, no render-time generation; each PNG generated lazily on first request. → `MockAssetTest` (emits N) + `MockControllerCest` (cold-cache gen).
+- [ ] **AC13** — One-byte-altered token → 404; untampered URL viewable by exactly Parts-Kit viewers. → `AssetsTest` (validate=false) + `MockControllerCest` (404 + gate).
 
 ### Non-Functional Requirements
 
-- [ ] **NFR1** — Concurrent first-request generation of the same hash from two HTTP requests never produces a corrupt PNG. Implementation uses temp-file + atomic `rename()`.
-- [ ] **NFR2** — Mock URLs are tamper-proof: the path token is an HMAC-signed payload (`Security::hashData`/`validateData`); any modification fails validation and yields 404. The on-disk filename is `sha1($validatedPayload)` — derived from server-validated data, never from raw request input — so path traversal is structurally impossible.
-- [ ] **NFR3** — Mock image access mirrors Parts Kit visibility. When `Settings::$requireViewPermission` is `true`, both the Parts Kit and its mock URLs require `parts-kit:view` (unauthorized requests receive 403). When `false`, both are public. If the Parts Kit renders for a user, its mock images load for that user — there is no independent devMode gate on images.
-- [ ] **NFR4** — If Imagick is missing, `partsKit.assets.make()` throws a clear `RuntimeException` naming the missing extension and the README workaround.
-- [ ] **NFR5** — The plugin loads correctly when Imager X is *not* installed (no fatal class-not-found errors); the integration only registers when `ImagerXIntegration::isAvailable()` returns true.
-- [ ] **NFR6** — Generation gracefully bounds disk usage: `MockImageGenerator::generate()` aborts and logs a warning when the cache directory contains more than 5,000 PNG files.
-- [ ] **NFR7** — `MockAssetBuilder::label()` rejects input over 200 characters with `InvalidArgumentException`.
-- [ ] **NFR8** — `MockController::actionView` runs the access check BEFORE signature validation, so an unauthorized request always receives 403 regardless of token validity — no oracle distinguishing a valid token from a forged one.
+- [ ] **NFR1** — Concurrent first-request generation never corrupts a PNG (temp-file + atomic `rename()`). → `MockImageGeneratorTest` (no temp residue; atomicity by construction).
+- [ ] **NFR2** — Tamper-proof HMAC token; on-disk filename `sha1($validatedPayload)`, never raw input (no traversal). → `AssetsTest`, `MockControllerCest`.
+- [ ] **NFR3** — Access mirrors Parts Kit visibility (403 when gated + unauthorized; public when off). → `MockControllerCest`.
+- [ ] **NFR4** — *(Manual / guard-shape)* Imagick missing → clear `RuntimeException` naming the extension + README. → `AssetsTest` guard assertion; manual on Imagick-less env (CI always has imagick).
+- [ ] **NFR5** — Plugin loads with Imager X **not** installed; integration registers only when available. → `ImagerXIntegrationTest` (runs in CI).
+- [ ] **NFR6** — Generation aborts + logs past 5,000 PNGs. → `MockImageGeneratorTest`.
+- [ ] **NFR7** — `label()` rejects > 200 chars with `InvalidArgumentException`. → `MockAssetBuilderTest`.
+- [ ] **NFR8** — Access check before signature validation (unauthorized → 403 regardless of token validity; no oracle). → `MockControllerCest` (`gateRunsBeforeValidation`).
 
-### Quality Gates
+---
 
-- [ ] `composer check-cs` clean
-- [ ] `composer phpstan` clean
-- [ ] Manual verification of all 10 functional ACs from a parts-kit template
-- [ ] Manual verification with Imager X Pro installed (AC8) and uninstalled (NFR7)
-- [ ] Manual verification of CP entry preview context (mock URL renders correctly inside the CP preview iframe)
-- [ ] README updated, including supported surface table and Imager X behavior matrix
+## Quality Gates
 
-## Success Metrics
+The original "manual verification of all ACs" gate is **replaced** by automated coverage; only the genuinely-unautomatable items remain manual.
 
-This is dev tooling — no production telemetry. Success is qualitative:
+- [ ] `composer test` green (unit + functional) locally and in CI (MySQL **and** PostgreSQL matrix).
+- [ ] `composer check-cs` clean.
+- [ ] `composer phpstan` clean (level 4) — including the typed-union `getWidth()` override.
+- [ ] Every feature-bearing unit (U1, U3–U11) has its test file committed **in the same change** as the implementation, written test-first.
+- [ ] Imager X tests skip cleanly when Imager X is absent (CI default) — no errors, no false failures.
+- [ ] **Manual:** AC8 with Imager X Pro installed (DDEV harness).
+- [ ] **Manual:** NFR4 on an Imagick-less environment (or accepted as a guard-shape assertion).
+- [ ] **Manual:** CP entry-preview context renders mock URLs.
+- [ ] README + CHANGELOG updated; consumer-project audit recorded in the PR.
 
-1. A Viget developer can scaffold a new parts-kit template for an image-consuming component without uploading or seeding any Craft assets.
-2. The same parts-kit template renders identically on a fresh checkout (no environment-specific asset state).
-3. Both Craft native and Imager X transform call sites work without special-casing in component templates.
+---
 
-## Dependencies & Prerequisites
+## Alternative Approaches Considered
 
-### Build / Runtime
+Evaluated in the brainstorm and rejected:
 
-- PHP 8.2+ (already required by the plugin)
-- Craft CMS 5.0+ (already required)
-- PHP `ext-imagick` (newly required — added to `composer.json`)
-- Bundled font: DejaVu Sans TTF (added to `src/resources/fonts/`)
+- **Base64 data URLs** — bloats HTML, defeats caching, no transforms.
+- **Pre-generation + real Craft transform pipeline** — needs a real Volume + DB rows per size; crosses from "mock" into "real ephemeral asset."
+- **External placeholder service (placehold.co, picsum)** — requires internet, no transforms, third-party dependency.
+- **Imager X custom Transformer registration** — Pro-only, requires per-call opt-in; `EVENT_BEFORE_TRANSFORM_IMAGE` is transparent.
+- **Sidecar `{hash}.json` config files** — unnecessary; the signed token already carries validated config.
+- **GD fallback when Imagick is missing** — YAGNI; Imagick is a standard Craft transform dependency and CI already loads it.
 
-### Optional integrations
+### Testing-approach alternatives (new in the TDD rework)
 
-- Imager X Pro — for transparent integration without per-call opt-in. Lite users see documented manual workaround. No-Imager projects unaffected.
+- **Pure-unit controller tests via direct action invocation** instead of functional HTTP — rejected. The functional connector works here (unlike sibling plugins) and HTTP-level tests prove headers, routing, and the permission gate that direct invocation would bypass. Use functional for `MockController`.
+- **Mock Imagick to unit-test the generator without `ext-imagick`** — rejected. CI already loads `imagick`; mocking it would test the mock, not the PNG. Generate real files and assert with `getimagesize()`.
+- **Add Imager X to `require-dev` to auto-test AC8** — rejected for v1. It's a soft dependency (Pro license); pulling it into dev deps complicates the matrix and licensing. Skip-when-absent tests + a manual DDEV check is the right cost/coverage trade.
 
-### No new composer requirements other than ext-imagick
-
-Specifically NOT adding:
-- `spacecatninja/imager-x` (soft dependency via `class_exists`)
-- Any image-generation library beyond Imagick
+---
 
 ## Risk Analysis & Mitigation
 
 | Risk | Likelihood | Impact | Mitigation |
 |---|---|---|---|
-| **Imagick absent on dev container** | Medium | High (mock unusable) | Boot-time check in `make()`; clear error message; README install guidance |
-| **Font missing on minimal Docker image** | Medium | Medium (text rendering breaks) | Bundle DejaVuSans.ttf with the plugin; fallback chain to system fonts |
-| **Imager X Lite user hits Pro-only short-circuit** | Low (Viget uses Pro) | Medium (5xx error) | README documents manual `{ noop: true }` workaround; no runtime detection (kept simple) |
-| **Concurrent generation corrupts cached file** | Low | Medium (broken image until refresh) | Atomic temp-file + rename pattern |
-| **Forged / tampered mock URL** | Low | High (unauthorized generation or disclosure) | HMAC signature (`Security::validateData`) — unforgeable without the app security key; cache filename is `sha1($validatedPayload)`, never raw input, so no path traversal |
-| **Mock used in a real (non-Parts-Kit) template** | Medium | Low (visual only, not security) | By design, images render wherever Parts Kit visibility allows; signed URLs prevent forgery; README states mocks are for Parts Kit templates only and are not a production asset substitute |
-| **Malicious template loops to fill disk via unique hashes** | Low (trusted dev env) | Low (storage/runtime is small) | 5,000-file cap in `MockImageGenerator::generate()`; generation aborts and logs a warning past the threshold |
-| **Long-label DoS via `queryFontMetrics`** | Low | Low | 200-char cap on `MockAssetBuilder::label()` |
-| **File proliferation fills disk** | Low | Low (storage/runtime is small) | `clear-caches/all` integration; documented in README |
-| **`MockAsset` autocomplete misleads authors into calling unsupported methods** | High | Low (clear runtime error) | `@method` PHPDoc on the class; `NotSupportedException` includes method name + README pointer |
-| **CP entry preview can't load mock URLs** | Low | Medium (preview broken for parts-kit-using components) | Verify in Phase 4; URL rule registers on site rules so should work |
-| **Plugin install order issues with Imager X** | Low | Medium (event listener doesn't fire) | `Craft::$app->onInit` deferral already in place ensures Imager X has loaded before our listener registers |
+| **Imagick absent on dev container** | Medium | High | Boot-time check in `make()`; clear error; README guidance. (CI unaffected — imagick preloaded.) |
+| **Font missing on minimal image** | Medium | Medium | Bundle DejaVuSans.ttf; system-font fallback chain; `MockImageGeneratorTest` font-chain case. |
+| **Imager X Lite user hits Pro-only short-circuit** | Low | Medium | README documents `{ noop: true }`; no runtime detection. |
+| **Concurrent generation corrupts cached file** | Low | Medium | Atomic temp-file + rename; `MockImageGeneratorTest` asserts no temp residue. |
+| **Forged / tampered mock URL** | Low | High | HMAC `validateData`; `sha1($validatedPayload)` filename; `AssetsTest` + `MockControllerCest`. |
+| **Imager X tests fail CI because the dep is absent** | Medium | Medium | `markTestSkipped()` guard; NFR5 guard test is the CI-run half. |
+| **PHPStan rejects the typed-union `getWidth()` override** | Medium | Low | Match Craft 5's exact signature; verify under `composer phpstan` in U4 before moving on. |
+| **Functional PNG-byte assertion flakiness** | Low | Low | Assert via `getimagesizefromstring()` on the response body; fixed `SECURITY_KEY` makes tokens deterministic. |
+| **Malicious template fills disk via unique hashes** | Low | Low | 5,000-file cap; `MockImageGeneratorTest` covers it. |
+| **Long-label DoS via `queryFontMetrics`** | Low | Low | 200-char cap; `MockAssetBuilderTest` covers it. |
+| **CP entry preview can't load mock URLs** | Low | Medium | Manual verify in U12; URL rule on site rules. |
 
-## Resource Requirements
-
-Single-developer implementation. Estimated effort: ~1-2 days for Phases 1-3 with manual verification, plus polish and docs in Phase 4. No infrastructure changes required.
+---
 
 ## Future Considerations
 
-Explicitly out of scope for v1 (deferred until a real need surfaces):
+Out of scope for v1 (deferred until a real need surfaces):
 
-- **Background color / text color customization** (`->bgColor`, `->textColor` builder methods)
-- **Format selection** (always PNG in v1; honoring `->format('webp')` later means adding a `format` key to the signed payload, switching the URL extension + `Content-Type`, and branching `MockImageGenerator` — additive, no API break)
-- **Pluggable image generators** (`->generator(callable)` escape hatch for picsum/AI/custom)
-- **Non-image asset kinds** (PDF, video — would require generator branching)
-- **Custom field support** on mocks (`->set('caption', ...)`)
-- **Plugin config knobs** for storage path / URL prefix
-- **Auto-injection of `noop: true` for Imager X Lite** (currently documented-only)
-- **`PartsKitAssetLike` interface** — decouple component code from the Asset hierarchy via a structural interface that both real Assets and MockAssets implement. Requires consumer-project audit (see Phase 4) to determine whether components type-hint on `Asset` or accept duck-typed values.
+- Background/text color customization (`->bgColor`, `->textColor`).
+- Format selection (PNG-only in v1; `format` key is additive to the signed payload).
+- Pluggable image generators (`->generator(callable)`).
+- Non-image asset kinds (PDF, video).
+- Custom field support on mocks.
+- Plugin config knobs for storage path / URL prefix.
+- Auto-injection of `noop: true` for Imager X Lite.
+- `PartsKitAssetLike` interface to decouple component code from the Asset hierarchy (needs the consumer audit from U12).
 
 ### Security considerations for v2 additions
 
-When implementing any of the deferred items, watch for these vectors:
+- **Pluggable generators** — RCE-shaped; needs an allowlist or opaque registered IDs.
+- **Custom field support** — hash inputs must include field values to prevent cache-collision pollution.
+- **Config knobs for storage path** — must reject paths outside `@storage` to prevent arbitrary overwrite via `rename()`.
 
-- **Pluggable image generators (`->generator(callable)`)** — RCE-shaped surface. Will need an allowlist of registered generator names, or a no-callable-accepted design (only opaque generator IDs registered via config).
-- **Custom field support** — hash inputs must include field values to prevent cache-collision-based pollution.
-- **Plugin config knobs for storage path** — must reject paths outside `@storage` to prevent arbitrary file overwrite via the `rename()` step in `MockImageGenerator`.
+---
 
-Adding any of the above should be possible additively without breaking the v1 API.
+## Dependencies & Prerequisites
 
-## Documentation Plan
+- PHP 8.2+ and Craft CMS 5.0+ (already required).
+- PHP `ext-imagick` (newly required — added to `composer.json`; already present in CI `PHP_EXTENSIONS`).
+- Bundled DejaVu Sans TTF (`src/resources/fonts/`).
+- Codeception suite (unit + functional through `\craft\test\Craft`), PHPStan level 4, ECS — all already wired and CI-enforced.
+- **Optional:** Imager X Pro for transparent integration (soft dependency via `class_exists`; not in dev deps).
 
-- [ ] README.md — new "Mock Assets" section (see Phase 4)
-- [ ] Inline PHPDoc — `@method` block on `MockAsset` listing supported subset
-- [ ] Inline PHPDoc — every public method on `MockAssetBuilder` with example call site
-- [ ] CHANGELOG.md — entry for v[next].0.0 announcing mock asset support and ext-imagick requirement
-- [ ] No separate API docs site — README is the primary reference
+---
 
 ## References & Research
 
 ### Internal references
 
 - Brainstorm: `docs/brainstorms/2026-05-25-mock-asset-brainstorm.md`
-- Existing services: `src/services/Assets.php:11`, `src/services/Navigation.php:16`
-- Existing controllers: `src/controllers/ViewController.php:17`, `src/controllers/ApiController.php:21`
-- Existing models: `src/models/MockAsset.php:23`, `src/models/MockAssetBuilder.php`, `src/models/Settings.php:7`
-- Plugin entry: `src/Plugin.php` (specifically `_registerUrlRules:122`, `attachEventHandlers:69`, `config():38-46`)
-- Permission registration: `src/Plugin.php:99-112`
-- Existing permission gate (Twig): `src/templates/root.twig:13`
+- Existing services: `src/services/Navigation.php` (component + registration pattern to mirror)
+- Existing controllers: `src/controllers/ViewController.php`, `src/controllers/ApiController.php` (`allowAnonymous`, action shape)
+- Existing model: `src/models/Settings.php`
+- Plugin entry: `src/Plugin.php` (`config()`, `attachEventHandlers()`, `_registerUrlRules()`, `getNavigation()`)
+- Permission gate (Twig): `src/templates/root.twig`
+- **Test patterns to mirror:** `tests/unit/services/NavigationTest.php` (unit style, fixtures), `tests/functional/PartsKitRouteCest.php` (functional route + permission-gate assertions), `tests/unit/NavNodeTest.php`, `tests/unit/HarnessBootTest.php`
+- Test harness config: `codeception.yml`, `tests/unit.suite.yml`, `tests/functional.suite.yml`, `tests/_craft/`
+- CI: `.github/workflows/ci.yml`, `.github/workflows/codecept.yml` (note `imagick` already in `PHP_EXTENSIONS`), `.github/workflows/package-contents.yml` (font must ship)
 
 ### Craft 5 source references
 
@@ -465,39 +673,33 @@ Adding any of the above should be possible additively without breaking the v1 AP
 - `vendor/craftcms/cms/src/elements/Asset.php:1888` — `getSrcset()` signature
 - `vendor/craftcms/cms/src/elements/Asset.php:2150` — `getUrl()` signature
 - `vendor/craftcms/cms/src/elements/Asset.php:2509` — `getWidth()` typed-union signature (NOT mixed)
-- `vendor/craftcms/cms/src/elements/Asset.php:1076` — `public ?string $alt = null;` (native property since 4.0)
-- `vendor/craftcms/cms/src/elements/Asset.php:1070` — `public ?string $kind = null;` (no getter — direct property)
-- `vendor/craftcms/cms/src/elements/Asset.php:185-207` — `KIND_IMAGE` and related constants
-- `vendor/craftcms/cms/src/helpers/ImageTransforms.php:270` — `normalizeTransform()` for all transform argument shapes
-- `vendor/craftcms/cms/src/helpers/Image.php:90` — `targetDimensions()` for mode-aware dimension resolution
-- `vendor/craftcms/cms/src/utilities/ClearCaches.php:42` — `EVENT_REGISTER_CACHE_OPTIONS` constant
+- `vendor/craftcms/cms/src/elements/Asset.php:1076` — `public ?string $alt`
+- `vendor/craftcms/cms/src/elements/Asset.php:1070` — `public ?string $kind`
+- `vendor/craftcms/cms/src/helpers/ImageTransforms.php:270` — `normalizeTransform()`
+- `vendor/craftcms/cms/src/helpers/Image.php:90` — `targetDimensions()`
+- `vendor/craftcms/cms/src/utilities/ClearCaches.php:42` — `EVENT_REGISTER_CACHE_OPTIONS`
 - `vendor/craftcms/cms/src/web/Response.php:245` — `sendFile()` signature
 
 ### Imager X references (Pro license)
 
-- `spacecatninja/craft-imager-x/src/services/ImagerService.php:46` — `EVENT_BEFORE_TRANSFORM_IMAGE` constant
-- `spacecatninja/craft-imager-x/src/events/TransformImageEvent.php` — event payload shape
-- `spacecatninja/craft-imager-x/src/transformers/TransformerInterface.php` — `transform()` contract (not used directly, but mirrors what we return)
-- `spacecatninja/craft-imager-x/src/models/NoopImageModel.php` — reference implementation to mirror for `MockTransformedImage`
+- `spacecatninja/imager-x/src/services/ImagerService.php:46` — `EVENT_BEFORE_TRANSFORM_IMAGE`
+- `spacecatninja/imager-x/src/events/TransformImageEvent.php` — event payload shape
+- `spacecatninja/imager-x/src/models/NoopImageModel.php` — reference to mirror for `MockTransformedImage`
 
 ### External references
 
 - Craft CMS 5.x docs — Assets: https://craftcms.com/docs/5.x/reference/element-types/assets.html
 - Craft CMS 5.x docs — Controllers: https://craftcms.com/docs/5.x/extend/controllers.html
-- Yii 2 `Security::validateData()` / `hashData()` — HMAC data signing: https://www.yiiframework.com/doc/api/2.0/yii-base-security#validateData()-detail
-- Craft CMS 5.x docs — `hash` Twig filter (HMAC, validated via `craft.app.security.validateData()`): https://craftcms.com/docs/5.x/reference/twig/filters.html#hash
-- Imager X extending: https://imager-x.spacecat.ninja/extending.html
-- Imagick docs — setFont: https://www.php.net/manual/en/imagick.setfont.php
-- Imagick docs — queryFontMetrics: https://www.php.net/manual/en/imagick.queryfontmetrics.php
+- Craft CMS 5.x docs — Testing: https://craftcms.com/docs/5.x/extend/testing.html
+- Yii 2 `Security::validateData()` / `hashData()`: https://www.yiiframework.com/doc/api/2.0/yii-base-security
+- Imagick `queryFontMetrics`: https://www.php.net/manual/en/imagick.queryfontmetrics.php
 
 ### Brainstorm decision summary
 
-All decisions from the brainstorm are reflected above. Notable resolved questions:
-
 - Default dimensions: **800×600**
-- Filename default: **auto-generated `mock-{w}x{h}.png`; setting filename derives extension/mimeType**
-- Focal point default: **null; `hasFocalPoint()` returns false**
+- Filename default: **auto `mock-{w}x{h}.png`; setting filename derives ext/mimeType**
+- Focal point default: **null; `hasFocalPoint()` false**
 - Asset kinds in v1: **image-only**
-- Hash inputs: **width, height, label** (keyed, HMAC-signed payload; no plugin version prefix; rely on clear-caches)
+- Hash inputs: **width, height, label** (keyed, HMAC-signed; no version prefix; rely on clear-caches)
 - Imager X Lite UX: **documented manual workaround only**
 - Plugin config knobs: **hardcoded for v1**

--- a/docs/plans/2026-05-25-feat-mock-asset-service-plan.md
+++ b/docs/plans/2026-05-25-feat-mock-asset-service-plan.md
@@ -1,0 +1,503 @@
+---
+title: Mock Asset Service for Parts Kit
+type: feat
+status: active
+date: 2026-05-25
+brainstorm: docs/brainstorms/2026-05-25-mock-asset-brainstorm.md
+---
+
+# feat: Mock Asset Service for Parts Kit
+
+## Enhancement Summary
+
+**Deepened on:** 2026-05-25
+**Review agents used:** security-sentinel, performance-oracle, code-simplicity-reviewer, architecture-strategist
+
+### Refinements applied
+
+1. **Phase split.** Phase 1 (foundation cleanup — constructor fix, `@property-read` typo, `getAssets()` getter) lands as a small separate PR before the feature work. Phase 2 starts on a clean base.
+2. **Builder pattern correction.** `MockAssetBuilder` now holds a config array and constructs the `MockAsset` in `one()` via `new MockAsset($config)`. No more mutating a half-built Asset mid-chain. Aligns with Yii's standard `new X($config)` idiom.
+3. **Imager X integration extracted to a service.** `src/services/ImagerXIntegration.php` registers conditionally in `Plugin::config()` under `class_exists`. Keeps the soft-dependency surface in one file, matches existing Navigation/Assets service pattern.
+4. **URL construction + signing extracted from `MockAsset`.** New `Assets::signedUrlForImage(int $w, int $h, ?string $label): string` method owns both routing and HMAC signing. The element no longer knows the controller's routing decision.
+5. **Performance: fully lazy, controller-only generation.** Template rendering does **zero** Imagick and zero filesystem work — `getUrl()`/`getImg()`/`getSrcset()` only emit signed URL strings. Every PNG is generated inside `MockController` on the first HTTP request for its URL, then cached. This drops render time for a 20-mock page to near-zero (no longer ~2-4s) and removes the per-request generation guard entirely.
+6. **Extensibility: keyed signed payload + transform normalization.** The signed payload is a keyed array (`['w'=>…, 'h'=>…, 'label'=>…]`), so future knobs (`format`, `bg`, `position`) slot in additively without breaking existing decode. All transform argument shapes — named handles (`'hero-transform'`), arrays, and `ImageTransform` objects — are normalized via `ImageTransforms::normalizeTransform()` before dimension resolution, so mode-aware sizing (crop/fit/stretch/letterbox) works uniformly.
+7. **Performance: drop ETag + 304.** `Cache-Control: public, max-age=31536000, immutable` is sufficient. Removes filemtime syscall, conditional-request branching, and NFR4 entirely.
+8. **Security: tamper-proof signed URLs + visibility mirrors Parts Kit.** Mock URLs carry an HMAC-signed payload (`Security::hashData`/`validateData` — the primitive behind Craft's `|hash` filter); the controller validates the signature and rejects any tampering with a 404. Access is **no longer** devMode-gated: a mock image is viewable by exactly whoever can view the Parts Kit (public, or `parts-kit:view`-gated, per `requireViewPermission`). Signing is what makes opening access safe — forged dimensions/labels are impossible without the app security key. Replaces the earlier `ForbiddenHttpException` hard-block.
+9. **Security: reorder access check before signature validation.** The controller runs its permission gate before validating the token, so unauthorized requests get a uniform 403 and can't probe which tokens are valid.
+10. **Security: hardcode `sendFile` disposition filename to `'mock.png'`.** Removes defense-in-depth concern about user-controlled header content.
+11. **Security: use `NotFoundHttpException` for 404, not custom response body.** Eliminates any future XSS risk from interpolated hash echo.
+12. **Security: cap label length at 200 chars** in `MockAssetBuilder::label()` to bound `queryFontMetrics` cost.
+13. **Security: cap directory file count at 5,000** in `MockImageGenerator::generate()`. Bounds disk-fill via malicious template loop.
+14. **LSP violation acknowledgment.** `MockAsset` class docblock explicitly states the structural-subtype contract — only read-time transform APIs are honored, mutations and persistence are unsupported by design.
+15. **Cut: static error PNG fallback.** Generation failure now lets the exception bubble. In dev, broken image = real signal, not noise to mask.
+16. **Cut: per-render devMode warning logging.** Replaced by the Parts Kit visibility gate plus tamper-proof signed URLs (item 8).
+17. **Cut: Lite-license boot detection.** README note suffices. Viget uses Pro anyway.
+18. **Cut: `@method` PHPDoc block on MockAsset.** Goes stale; `NotSupportedException` messages are the source of truth.
+19. **Durable URLs for free.** Because the signed token carries the (validated) config, the controller generates the PNG on demand — both on first request and after a cache clear — with no sidecar `{hash}.json` files and no 404-then-refresh. Generation is controller-only; there is no render-time generation path.
+
+### Rejected suggestions (with reasoning)
+
+- **Cut bundled DejaVuSans.ttf** — best-practices research showed this is the standard Craft-community pattern. Removing it surfaces portability bugs on Alpine/slim Docker images. ~750KB is a fair price.
+- **Cut fluent setters, keep only `configure(array)`** — user explicitly chose both in the brainstorm. Reviewer didn't see that decision.
+- **Inline `MockImageGenerator` as a private method** — architecture review confirmed static helper is the right fit; the file isolation aids future refactors.
+- **Cut atomic temp-file + rename** — 5 lines of code for a real correctness property under concurrency. Keep.
+
+### New considerations discovered
+
+- A malicious template can fill `@storage/runtime/parts-kit-mocks/` by looping unique hashes. Bounded by 5,000-file cap.
+- Future v2 security notes added for pluggable generators (RCE shape), custom field support (cache collision), and config knobs for storage path (arbitrary file overwrite via rename).
+- Viget consumer projects should be audited for `Asset $param` type-hints to confirm component code accepts MockAsset via the extends-Asset path (vs untyped duck-typing).
+
+---
+
+## Overview
+
+Add a fully functional `MockAsset` element class (extending `craft\elements\Asset`) and a fluent / hash-config builder API so that Parts Kit template authors can render placeholder images without needing real assets uploaded locally. The mock generates real PNG files on disk lazily — on the first request for each URL (cached by SHA-1 hash of config) — serves them through a plugin controller route addressed by a **tamper-proof, HMAC-signed URL**, and integrates transparently with both Craft's native transform pipeline and Imager X (Pro) via `EVENT_BEFORE_TRANSFORM_IMAGE`. Image access **mirrors Parts Kit visibility** — if a user can view the Parts Kit, they can load its mock images.
+
+## Problem Statement
+
+Parts Kit lets developers preview Twig components in isolation — but most production components consume Craft `Asset` instances (for images: hero photos, thumbnails, avatars, etc.). In local development:
+
+1. Assets are not in sync with production (no CDN backfill, no fresh-checkout dump),
+2. Asset IDs differ across machines and environments,
+3. Setting up a real asset just to preview a component is high-friction work for what should be a no-setup dev tool.
+
+The existing WIP `MockAsset` class extends `Asset` but throws `NotSupportedException` on ~95% of methods and renders a base64 PNG inline. This breaks the moment a component calls `asset.getImg()`, `asset.getUrl({width: 400})`, `asset.alt`, or any transform pipeline. It also bloats HTML and defeats browser caching.
+
+## Proposed Solution
+
+A complete rewrite of `MockAsset` that implements the **subset of `Asset` that real-world Twig component templates actually use** (dimensions, transforms, alt, title, filename/extension/mimeType/kind, focal point) and routes image production through a plugin controller serving real PNG files from `@storage/runtime/parts-kit-mocks/`. Each mock URL is a **tamper-proof, HMAC-signed token** (via Yii's `Security`, surfaced in Craft as the `|hash` filter); the controller validates the signature and, because the validated config travels in the URL, **lazily generates the PNG on the first request** (and regenerates it after any cache clear). Template rendering itself performs no image generation — it only emits signed URLs. Image access **mirrors Parts Kit visibility** rather than gating on devMode. Imager X integration uses an `EVENT_BEFORE_TRANSFORM_IMAGE` listener that populates `transformedImages` with a custom `MockTransformedImage` model, transparently short-circuiting the pipeline for mocks.
+
+**Target Twig usage:**
+
+```twig
+{# Hash config — terse #}
+{% set hero = partsKit.assets.make({
+  width: 1600,
+  height: 900,
+  label: 'Hero',
+  alt: 'Hero photo',
+}).one %}
+
+{# Or fluent chain — incremental #}
+{% set thumb = partsKit.assets.make
+  .width(400)
+  .height(300)
+  .label('Thumbnail')
+  .one %}
+
+{# Components consume mocks identically to real assets #}
+{{ Image({ asset: hero, transform: 'hero-transform' }) }}
+{{ craft.imagerx.transformImage(hero, { width: 800, mode: 'fit' }) }}
+```
+
+## Technical Approach
+
+### Architecture
+
+```mermaid
+flowchart TD
+    A[Twig template] -->|partsKit.assets.make| B[Assets service]
+    B -->|new MockAssetBuilder| C[MockAssetBuilder]
+    C -->|->one| D[MockAsset element]
+    A -->|asset.getUrl/getImg| D
+    D -->|signs URL (no generation)| E[/parts-kit/mock/&lt;signed-token&gt;.png]
+    E -->|HTTP GET| F[MockController::actionView<br/>Parts Kit gate + validateData]
+    F -->|sendFile| G[(@storage/runtime/parts-kit-mocks/&lt;hash&gt;.png)]
+    F -.->|first request / miss → generate from validated config| H[MockImageGenerator]
+    H -.->|atomic write| G
+    I[craft.imagerx.transformImage] -->|ImagerService::EVENT_BEFORE_TRANSFORM_IMAGE| J[Plugin event listener]
+    J -->|asset instanceof MockAsset?| K{Yes?}
+    K -->|Yes| L[Populate $event->transformedImages with MockTransformedImage]
+    K -->|No| M[Pass through to default transformer]
+    L -->|points at MockAsset URL| E
+```
+
+### File Inventory
+
+| File | Purpose | Status |
+|---|---|---|
+| `src/Plugin.php` | Add URL rule, ClearCaches registration, `getAssets()` getter, fix `@property-read` typo. Imager X registration deferred to `ImagerXIntegration` service | Modify |
+| `src/services/Assets.php` | `make(array $config = [])` returns configured `MockAssetBuilder`; boot-time Imagick check; `signedUrlForImage(int $w, int $h, ?string $label): string` builds the tamper-proof HMAC-signed URL | Modify |
+| `src/services/ImagerXIntegration.php` | Conditionally registers `EVENT_BEFORE_TRANSFORM_IMAGE` listener; isolates soft-dependency surface | New |
+| `src/models/MockAsset.php` | Full rewrite: implements supported asset surface, overrides four transform methods to emit signed URLs (no generation at render), retains `NotSupportedException` for the rest with helpful messages. Class docblock acknowledges LSP violation as intentional | Rewrite |
+| `src/models/MockAssetBuilder.php` | Holds config array, constructs `MockAsset` in `one()`. Adds `configure(array)`, `label` (200-char cap), `alt`, `title`, `filename`, `focalPoint` builder methods | Extend |
+| `src/models/MockTransformedImage.php` | Implements `TransformedImageInterface` for Imager X short-circuit | New |
+| `src/helpers/MockImageGenerator.php` | Imagick PNG generation invoked only by the controller; `generate()`, font detection, atomic write, scale-to-fit text, file-count cap | New |
+| `src/controllers/MockController.php` | `actionView(string $token): Response` — access mirrors Parts Kit visibility; validates HMAC signature (404 on tamper); lazily generates the PNG from validated config on first request; serves PNG via `sendFile` with hardcoded disposition filename | New |
+| `src/resources/fonts/DejaVuSans.ttf` | Bundled font (DejaVu Sans — Bitstream Vera license, redistributable) | New |
+| `composer.json` | Add `"ext-imagick": "*"` to require | Modify |
+| `README.md` | Document Mock Asset API, Imager X Pro/Lite behavior, supported surface, "dev-only" guarantee | Modify |
+
+### Implementation Phases
+
+#### Phase 1: Foundation cleanup (separate PR)
+
+Small, mergeable-on-its-own PR that fixes latent bugs unrelated to the mock asset feature. Lands first so Phase 2 builds on a clean base.
+
+**Tasks**
+
+- [ ] Fix `MockAsset::__construct()` to accept `$config = []` and call `parent::__construct($config)`. Current empty no-arg breaks `new MockAsset(['width' => 800])`.
+- [ ] Fix `MockAsset::init()` to call `parent::init()`. Per Craft 5 source (`Asset::init()` line 1288), init is minimal, no DB lookups, safe to call.
+- [ ] Fix `Plugin.php` `@property-read Assets $assetService` → `@property-read Assets $assets` to match actual component key.
+- [ ] Add `getAssets(): Assets` getter to `Plugin.php` mirroring the existing `getNavigation()` pattern.
+- [ ] Audit `getNavigation()` for the same drift — if `@property-read Navigation $navigation` is missing, add it. Establish convention: every component in `config()['components']` gets a typed getter AND a matching `@property-read` line.
+- [ ] Run `composer check-cs` and `composer phpstan` clean before moving on.
+
+**Note:** `composer.json` ext-imagick addition and bundled font moved to Phase 2 — they're feature dependencies, not foundation cleanup.
+
+**Success criteria:** Existing parts-kit functionality unchanged; static analysis passes; `new MockAsset(['width' => 800])` instantiates without exception; this PR lands cleanly before Phase 2 begins.
+
+#### Phase 2: Core mock implementation
+
+The meaty phase — write everything the Craft transform pipeline touches.
+
+**Feature dependencies added in this phase:**
+
+- [ ] Add `"ext-imagick": "*"` to `composer.json` `require`.
+- [ ] Create `src/resources/fonts/` directory and add `DejaVuSans.ttf` (Bitstream Vera license, redistributable). Ensure included in composer package via default plugin autoload.
+
+**Tasks**
+
+- [ ] **`MockImageGenerator` helper** (`src/helpers/MockImageGenerator.php`):
+  - Class-level docblock explains: stateless static helper, first occupant of the `helpers/` namespace, isolated for testability and future refactor.
+  - Static `generate(string $path, int $width, int $height, ?string $label): void` — the only generation entry point; called exclusively from `MockController` on a cache miss.
+  - Font detection chain: bundled `DejaVuSans.ttf` → `/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf` → `/System/Library/Fonts/Helvetica.ttc` → throw `RuntimeException` with install hint
+  - Render: bg `#999999` (AA-contrast with white text), centered white label
+  - Default label: `"{$width}x{$height}"`; respect user-provided override
+  - Scale-to-fit: start `(int)(min($w, $h) * 0.2)`, use `queryFontMetrics()` to step down until fit, floor at 8px
+  - PNG output: `setImageFormat('png')`, `setImageCompressionQuality(75)`, `stripImage()`
+  - **Atomic write**: write to `$path.tmp.{bin2hex(random_bytes(8))}` then `rename()` to final path
+  - **File-count cap (security):** before writing, count `*.png` files in the directory. If > 5,000, log `Craft::warning('parts-kit mocks cache full')` and abort generation (callers handle missing file as a normal cache miss).
+  - **NO try/catch fallback** — let Imagick exceptions bubble. In dev, broken image is the desired signal that the env is broken (Imagick missing, no fonts, disk full). The `MockAsset::getUrl()` caller can decide whether to swallow.
+
+- [ ] **`MockAsset` rewrite** (`src/models/MockAsset.php`):
+  - Class docblock explicitly acknowledges LSP violation:
+    ```
+    /**
+     * MockAsset is a structural subtype of craft\elements\Asset, honoring ONLY
+     * the read-time transform/metadata APIs needed by typical Twig component
+     * templates. Mutations, persistence, field access, and volume-related calls
+     * are intentionally unsupported and will throw NotSupportedException.
+     * This violates LSP by design; the alternative (a composition wrapper) cannot
+     * pass Craft/ImagerX type-hints that require `craft\elements\Asset`.
+     */
+    ```
+  - Extend `craft\elements\Asset`
+  - Restore `__construct($config = [])`, `init()` (Phase 1 already done)
+  - In `init()`: set sane defaults — `$this->id = -1`, `$this->kind = Asset::KIND_IMAGE`, `setScenario(self::SCENARIO_CREATE)`
+  - **Private typed properties for builder-set values:** `?int $_width`, `?int $_height`, `?string $_label`, `?string $_filename`, `?array $_focalPoint`. The `alt` and `title` properties are inherited from `Asset` / `Element` and used directly.
+  - **Per-instance URL memo:** `private array $_urlCache = [];` — keyed by normalized transform args; caches the signed URL string so repeated `getUrl()` calls skip re-signing. No generation or filesystem access is involved (generation is controller-only).
+  - **Override transform-producing methods** with exact Craft 5 signatures:
+    - `getUrl(mixed $transform = null, ?bool $immediately = null): ?string` — memoized; normalizes `$transform` via `ImageTransforms::normalizeTransform()`, resolves it to the final width/height, then delegates to `Plugin::getInstance()->getAssets()->signedUrlForImage($w, $h, $this->_label)`. Emits a URL only — no generation.
+    - `getImg(mixed $transform = null, ?array $sizes = null): ?Markup` — mirror Craft's default: `Html::tag('img', '', ['src', 'width', 'height', 'srcset', 'alt'])`. Returns null when `$this->kind !== Asset::KIND_IMAGE` (matches Craft).
+    - `getSrcset(array $sizes, mixed $transform = null): string|false` — composes the srcset string purely from signed URLs (one per size, via `signedUrlForImage`). No generation: each size's PNG is created lazily by the controller when the browser fetches that URL.
+    - `getUrlsBySize(array $sizes, mixed $transform = null): array`
+  - **Override `getWidth(array|string|ImageTransform $transform = null): ?int`** — note the typed union, NOT `mixed` (LSP). Normalize `$transform` via `ImageTransforms::normalizeTransform()` first (so named handles, arrays, and `ImageTransform` objects all resolve), then compute via `Image::targetDimensions($this->_width, $this->_height, $t->width, $t->height, $t->mode, $t->upscale)`. This is mode-aware: `crop`, `fit`, `stretch`, and `letterbox` all yield the correct target size (a placeholder has no subject to crop, so mode only affects dimensions).
+  - **Override `getHeight(mixed $transform = null): ?int`** — same normalization + dimension resolution.
+  - **Implement metadata getters/setters:** `getFilename()`, `setFilename()`, `getExtension()`, `getMimeType()`, `getHasFocalPoint()`, `getFocalPoint()`, `setFocalPoint()`.
+  - **Filename auto-derivation:** default filename `mock-{w}x{h}.png`. When `setFilename('hero.jpg')` is called, derive extension/mimeType from the path. `kind` remains `'image'` always in v1.
+  - **Signed payload & cache key:** the canonical payload is a **keyed** array, `Json::encode(['w' => $w, 'h' => $h, 'label' => $this->_label], JSON_THROW_ON_ERROR)` — keyed (not positional) so future fields (`format`, `bg`, `position`) are additive and don't break decode. The URL token is `Security::hashData($payload)`, URL-safe-encoded; the on-disk cache filename is `sha1($payload)`. The controller (post-`validateData`) recomputes `sha1($payload)` to locate or generate the file. **Extension points:** add a key here, read it in `MockController`, and pass it through to `MockImageGenerator::generate()` — the signature and cache key absorb the new field automatically (new config ⇒ new hash ⇒ fresh PNG).
+  - **Field access override:** `getFieldValue($handle, $siteId = null)` throws `NotSupportedException` with message `"MockAsset does not support custom fields. Field '{$handle}' was requested. Use ->alt, ->title, or ->label on the builder, or pass a real Asset to this component."`
+  - **Explicit overrides for DB-touching methods** (`getVolume`, `getFolder`, `getFs`, `getUploader`, `getFieldLayout`, `getFieldValues`, `save`, `delete`, `validate`) — throw `NotSupportedException(__METHOD__ . ' is not supported on MockAsset; see README.')`. Per architecture review, don't try to enumerate every Element method exhaustively — focus on the ones that would query the DB if not stubbed.
+
+- [ ] **`MockAssetBuilder` rewrite** (`src/models/MockAssetBuilder.php`):
+  - **Holds config array, not a MockAsset instance.** `private array $_config = [];` Constructs the `MockAsset` only in `one()` via `new MockAsset($this->_config)`. No more mid-chain half-built Asset.
+  - `configure(array $config): self` — merges into `$this->_config`. Unknown keys throw `InvalidArgumentException("Unknown mock asset config key: '{$key}'")`.
+  - Fluent setters: `width(int)`, `height(int)`, `label(string)`, `alt(string)`, `title(string)`, `filename(string)`, `focalPoint(array)`. Each writes to `$this->_config` and returns `$this`.
+  - `label(string $value)`: `trim($value)`; reject `if (strlen($value) > 200) throw new InvalidArgumentException('Mock label exceeds 200 characters.');` (security: bounds `queryFontMetrics` cost).
+  - `one(): MockAsset` — applies defaults (width=800, height=600 if unset; focalPoint stays null) then constructs `new MockAsset($this->_config)`.
+
+- [ ] **`Assets` service extension** (`src/services/Assets.php`):
+  - `make(array $config = []): MockAssetBuilder` — wraps `(new MockAssetBuilder())->configure($config)` when config provided, else returns empty builder.
+  - Boot-time Imagick check inside `make()`: `if (!extension_loaded('imagick')) throw new RuntimeException('The Imagick PHP extension is required for parts-kit mock assets. Install ext-imagick or remove parts-kit mock usage.')`
+  - `signedUrlForImage(int $w, int $h, ?string $label): string` — single source of truth for routing **and** signing. Builds the canonical **keyed** payload (`Json::encode(['w' => $w, 'h' => $h, 'label' => $label])`), signs it with `Craft::$app->getSecurity()->hashData($payload)` (HMAC keyed by the app security key — the same primitive behind Craft's `|hash` Twig filter), URL-safe-encodes the result, and wraps it: `UrlHelper::siteUrl($partsKitDir . '/mock/' . StringHelper::base64UrlEncode($signed) . '.png')`. `MockAsset::getUrl()` delegates here.
+    - Use `yii\helpers\StringHelper::base64UrlEncode()` / `base64UrlDecode()` for transport-safe encoding of the signed payload (avoids `/`, `+`, `=` in the path segment). The controller reverses this before `validateData()`.
+
+- [ ] **`MockController`** (`src/controllers/MockController.php`):
+  - Namespace: `viget\partskit\controllers`
+  - Extends `craft\web\Controller`
+  - `protected array|bool|int $allowAnonymous = ['view'];` (access decisions happen inside the action, mirroring the Parts Kit gate)
+  - `actionView(string $token): Response`:
+    1. **Access mirrors Parts Kit visibility (before signature validation — removes timing oracle):** if `Plugin::getInstance()->getSettings()->requireViewPermission` → `$this->requirePermission('parts-kit:view')`. **No devMode/admin hard-block** — if a user can view the Parts Kit, they can load its mock images. When `requireViewPermission` is `false`, `allowAnonymous` leaves the route public, exactly like the Parts Kit itself.
+    2. **Validate the signature (tamper-proof):** `$payload = Craft::$app->getSecurity()->validateData(StringHelper::base64UrlDecode($token)); if ($payload === false) throw new NotFoundHttpException();` — the HMAC is keyed by the app security key, so a tampered or hand-crafted token can't be forged and resolves to a standard 404 (no XSS risk; Craft renders its own error page).
+    3. **Decode the validated config:** `$config = Json::decode($payload);` then read `$config['w']`, `$config['h']`, `$config['label']`. These values are trusted — they came from a signature the server itself produced. New payload keys (e.g. `format`) are read here.
+    4. Resolve path: `$path = Craft::getAlias('@storage/runtime/parts-kit-mocks/') . sha1($payload) . '.png';` — the filename is derived from server-validated data, never from raw request input, so path traversal is structurally impossible (`basename()` is no longer needed).
+    5. **Generate on first request (fully lazy):** `if (!file_exists($path)) MockImageGenerator::generate($path, $config['w'], $config['h'], $config['label']);` — this is the **only** place images are generated. The first request for a URL creates the PNG; every later request (and any request after `clear-caches/all`) hits the cache or regenerates from the same signed config. No render-time generation, no sidecar files, no 404-then-refresh.
+    6. Set headers: `Cache-Control: public, max-age=31536000, immutable`. **No ETag, no 304 logic** — `immutable` is sufficient; the syscall and conditional-request branching are wasted complexity.
+    7. `return $this->response->sendFile($path, 'mock.png', ['mimeType' => 'image/png', 'inline' => true]);` — hardcoded `'mock.png'` for the disposition filename (defense in depth against future header-injection via filename interpolation)
+
+- [ ] **`Plugin.php` modifications**:
+  - In `_registerUrlRules()`: add `$event->rules[$partsKitDir . '/mock/<token:[A-Za-z0-9_-]+>\.png'] = 'parts-kit/mock/view';` — the segment is a URL-safe base64 signed token, not a bare hash.
+  - In `attachEventHandlers()`: register `ClearCaches::EVENT_REGISTER_CACHE_OPTIONS` listener:
+    ```php
+    Event::on(ClearCaches::class, ClearCaches::EVENT_REGISTER_CACHE_OPTIONS,
+      function (RegisterCacheOptionsEvent $event) {
+        $event->options[] = [
+          'key' => 'parts-kit-mocks',
+          'label' => Craft::t('parts-kit', 'Parts Kit mock images'),
+          'action' => Craft::getAlias('@storage/runtime/parts-kit-mocks'),
+        ];
+      });
+    ```
+  - **Note:** No per-render devMode warning is added. Abuse safety is enforced by the controller: access mirrors the Parts Kit gate, and the tamper-proof signed token means only server-issued URLs ever resolve (no forged dimensions/labels). Mocks are documented as Parts Kit-only and not a production asset substitute.
+
+**Success criteria:** All functional acceptance criteria pass; static analysis clean; existing parts-kit functionality unchanged.
+
+#### Phase 3: Imager X integration
+
+Soft-dependency on Imager X. Pro license enables full transparent integration; Lite gets a documented manual workaround in README. Integration is extracted into its own service per architecture review.
+
+**Tasks**
+
+- [ ] **`MockTransformedImage` model** (`src/models/MockTransformedImage.php`):
+  - Implements `spacecatninja\imagerx\models\TransformedImageInterface`
+  - Mirror `NoopImageModel` structure (`vendor/spacecatninja/imager-x/src/models/NoopImageModel.php` in projects that have Imager X installed — fall back to interface contract if not locally available)
+  - Constructor accepts `MockAsset $asset, array $transform`
+  - Methods return: `getUrl()` → `$asset->getUrl($transform)`, `getWidth()` and `getHeight()` → resolved via our own `Image::targetDimensions()`, `getPath()` → the disk path, `getExtension()` → 'png', `getMimeType()` → 'image/png'
+  - **Class file must remain loadable even if Imager X is absent.** Use guarded loading via Composer autoloader plus `class_exists` check in `ImagerXIntegration::register()` before any reference. No top-level `use` of Imager X types in `Plugin.php`.
+
+- [ ] **`ImagerXIntegration` service** (`src/services/ImagerXIntegration.php`):
+  - Extends `yii\base\Component`
+  - Static `isAvailable(): bool` → `class_exists(\spacecatninja\imagerx\services\ImagerService::class)`
+  - `register(): void` — call from `Plugin::init`. Attaches `EVENT_BEFORE_TRANSFORM_IMAGE` listener:
+    ```php
+    public function register(): void
+    {
+        if (!self::isAvailable()) {
+            return;
+        }
+        Event::on(
+            \spacecatninja\imagerx\services\ImagerService::class,
+            \spacecatninja\imagerx\services\ImagerService::EVENT_BEFORE_TRANSFORM_IMAGE,
+            $this->_handleBeforeTransform(...)
+        );
+    }
+
+    private function _handleBeforeTransform(\spacecatninja\imagerx\events\TransformImageEvent $event): void
+    {
+        if (!$event->image instanceof MockAsset) {
+            return;
+        }
+        $event->transformedImages = array_map(
+            fn(array $t) => new MockTransformedImage($event->image, $t),
+            $event->transforms
+        );
+    }
+    ```
+
+- [ ] **`Plugin::config()`** — register the new service:
+  ```php
+  'components' => [
+      'navigation' => Navigation::class,
+      'assets' => Assets::class,
+      'imagerXIntegration' => ImagerXIntegration::class,
+  ],
+  ```
+
+- [ ] **`Plugin::init()`** — call `$this->get('imagerXIntegration')->register();` after `attachEventHandlers()`. (Service handles the `isAvailable()` guard internally.)
+
+- [ ] **No Lite-license boot detection.** Document the manual `{ noop: true }` workaround in README. Don't add runtime detection — Viget uses Pro, and the warning would be noise for the 0.1% Lite case.
+
+**Success criteria:** AC8 passes; non-Imager-X projects unaffected (plugin boots cleanly without Imager X installed); README documents the Lite workaround.
+
+#### Phase 4: Polish & docs
+
+**Tasks**
+
+- [ ] **README.md updates**:
+  - New section "Mock Assets" with the Twig usage examples from this plan
+  - Document the supported `Asset` surface (and what throws)
+  - Document Imager X Pro vs Lite behavior, including the manual `{ noop: true }` workaround for Lite
+  - Note: mock image access mirrors Parts Kit visibility — public when `requireViewPermission` is off, otherwise gated on `parts-kit:view`. URLs are HMAC-signed and tamper-proof; an altered token returns `404`. Mocks are intended for Parts Kit templates only, not as a production asset substitute.
+  - Note: cache wipes with `php craft clear-caches/all`
+  - Note: file proliferation — different labels create different cached PNGs; cap is 5,000 files per directory
+- [ ] Verify all `NotSupportedException` messages name the unsupported method and point to README
+- [ ] **Audit one or two Viget consumer projects** for `Asset $param` type-hints in components. Confirm the extends-Asset path works for typed code. Document any patterns where components are untyped so v2 can consider an interface-based alternative.
+- [ ] Test in CP entry preview context to verify mock URLs work outside the parts-kit iframe
+- [ ] Final pass: `composer check-cs && composer phpstan`
+
+**Success criteria:** README documents the full API; CP preview context verified; CI green; consumer-project audit recorded in the PR description.
+
+## Alternative Approaches Considered
+
+These were evaluated in the brainstorm and explicitly rejected:
+
+- **Base64 data URLs:** bloats HTML, defeats browser caching, can't run Craft transforms.
+- **Pre-generation + real Craft transform pipeline:** requires auto-provisioning a real Volume and creating DB rows per unique size. Crosses the line from "mock" into "real ephemeral asset"; the user explicitly preferred no DB writes.
+- **External placeholder service (placehold.co, picsum):** requires internet, no transform support, third-party dependency.
+- **Imager X custom Transformer registration:** Pro-only, requires authors to opt in via `transformer: 'mock'` per call. `EVENT_BEFORE_TRANSFORM_IMAGE` does it transparently based on asset type.
+- **Sidecar `{hash}.json` config files for URL durability:** unnecessary — the tamper-proof signed token already carries the (HMAC-validated) config, so the controller regenerates a cleared PNG on demand without any sidecar file. Durability comes for free from the signing scheme.
+- **GD fallback when Imagick is missing:** YAGNI. Imagick is already a Craft transform dependency in most production stacks; we add it as a composer requirement.
+
+## Acceptance Criteria
+
+### Functional Requirements
+
+- [ ] **AC1** — `partsKit.assets.make({width: 800, height: 600}).one` returns a `MockAsset` whose `.getUrl()` returns a URL matching `/parts-kit/mock/[A-Za-z0-9_-]+\.png` (a URL-safe, HMAC-signed token).
+- [ ] **AC2** — A GET to the URL from AC1 by a requester who can view the Parts Kit returns HTTP 200, `Content-Type: image/png`, `Cache-Control: public, max-age=31536000, immutable`, and a PNG of exact pixel dimensions 800×600.
+- [ ] **AC3** — `partsKit.assets.make.one` (no setters) renders an 800×600 PNG (the default).
+- [ ] **AC4** — `partsKit.assets.make({width: 800, height: 600, alt: 'Hero'}).one.getImg()` renders `<img>` with `src`, `width=800`, `height=600`, `alt="Hero"` attributes populated.
+- [ ] **AC5** — `partsKit.assets.make({width: 1600, height: 900}).one.getUrl({width: 400, mode: 'fit'})` returns a URL that serves a 400×225 PNG (aspect-preserved via `Image::targetDimensions`).
+- [ ] **AC6** — Two identically-configured mocks produce the same hash, generate one file on disk, and return the same URL.
+- [ ] **AC7** — Changing only `label` (e.g. `{label: 'Hero'}` vs `{label: 'Thumbnail'}`) produces a different hash and a separate file on disk (this is intentional and documented).
+- [ ] **AC8** — With Imager X Pro installed, `craft.imagerx.transformImage(mock, {width: 400})` returns a `MockTransformedImage` whose URL serves a 400-px-wide PNG. `LocalSourceImageModel::getLocalCopy()` is never invoked.
+- [ ] **AC9** — `php craft clear-caches/all` empties `@storage/runtime/parts-kit-mocks/` (verified by listing the directory before and after).
+- [ ] **AC10** — Calling any unsupported `Asset` method (e.g. `mock.getVolume()`, `mock.getFolder()`, `mock.getFieldValue('caption')`) throws `NotSupportedException` whose message includes the method name AND a pointer to the README.
+- [ ] **AC11** — Template rendering performs zero image generation and zero filesystem access: `getUrl()`/`getImg()`/`getSrcset()` only build signed URL strings (verifiable by asserting Imagick is never instantiated and no file is touched during a render). All generation happens inside `MockController`.
+- [ ] **AC12** — A `getSrcset` call with N sizes triggers no generation at render time; it returns N signed URLs, and each size's PNG is generated lazily on its first HTTP request (then cached). Requesting all N URLs on a cold cache produces N correctly-sized PNGs.
+- [ ] **AC13** — A mock URL whose signed token has been altered by even one byte returns HTTP 404 via `Security::validateData()`. An untampered URL is viewable by exactly whoever can view the Parts Kit: public when `requireViewPermission = false`, gated on `parts-kit:view` when `true`. There is no separate devMode gate on mock images.
+
+### Non-Functional Requirements
+
+- [ ] **NFR1** — Concurrent first-request generation of the same hash from two HTTP requests never produces a corrupt PNG. Implementation uses temp-file + atomic `rename()`.
+- [ ] **NFR2** — Mock URLs are tamper-proof: the path token is an HMAC-signed payload (`Security::hashData`/`validateData`); any modification fails validation and yields 404. The on-disk filename is `sha1($validatedPayload)` — derived from server-validated data, never from raw request input — so path traversal is structurally impossible.
+- [ ] **NFR3** — Mock image access mirrors Parts Kit visibility. When `Settings::$requireViewPermission` is `true`, both the Parts Kit and its mock URLs require `parts-kit:view` (unauthorized requests receive 403). When `false`, both are public. If the Parts Kit renders for a user, its mock images load for that user — there is no independent devMode gate on images.
+- [ ] **NFR4** — If Imagick is missing, `partsKit.assets.make()` throws a clear `RuntimeException` naming the missing extension and the README workaround.
+- [ ] **NFR5** — The plugin loads correctly when Imager X is *not* installed (no fatal class-not-found errors); the integration only registers when `ImagerXIntegration::isAvailable()` returns true.
+- [ ] **NFR6** — Generation gracefully bounds disk usage: `MockImageGenerator::generate()` aborts and logs a warning when the cache directory contains more than 5,000 PNG files.
+- [ ] **NFR7** — `MockAssetBuilder::label()` rejects input over 200 characters with `InvalidArgumentException`.
+- [ ] **NFR8** — `MockController::actionView` runs the access check BEFORE signature validation, so an unauthorized request always receives 403 regardless of token validity — no oracle distinguishing a valid token from a forged one.
+
+### Quality Gates
+
+- [ ] `composer check-cs` clean
+- [ ] `composer phpstan` clean
+- [ ] Manual verification of all 10 functional ACs from a parts-kit template
+- [ ] Manual verification with Imager X Pro installed (AC8) and uninstalled (NFR7)
+- [ ] Manual verification of CP entry preview context (mock URL renders correctly inside the CP preview iframe)
+- [ ] README updated, including supported surface table and Imager X behavior matrix
+
+## Success Metrics
+
+This is dev tooling — no production telemetry. Success is qualitative:
+
+1. A Viget developer can scaffold a new parts-kit template for an image-consuming component without uploading or seeding any Craft assets.
+2. The same parts-kit template renders identically on a fresh checkout (no environment-specific asset state).
+3. Both Craft native and Imager X transform call sites work without special-casing in component templates.
+
+## Dependencies & Prerequisites
+
+### Build / Runtime
+
+- PHP 8.2+ (already required by the plugin)
+- Craft CMS 5.0+ (already required)
+- PHP `ext-imagick` (newly required — added to `composer.json`)
+- Bundled font: DejaVu Sans TTF (added to `src/resources/fonts/`)
+
+### Optional integrations
+
+- Imager X Pro — for transparent integration without per-call opt-in. Lite users see documented manual workaround. No-Imager projects unaffected.
+
+### No new composer requirements other than ext-imagick
+
+Specifically NOT adding:
+- `spacecatninja/imager-x` (soft dependency via `class_exists`)
+- Any image-generation library beyond Imagick
+
+## Risk Analysis & Mitigation
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| **Imagick absent on dev container** | Medium | High (mock unusable) | Boot-time check in `make()`; clear error message; README install guidance |
+| **Font missing on minimal Docker image** | Medium | Medium (text rendering breaks) | Bundle DejaVuSans.ttf with the plugin; fallback chain to system fonts |
+| **Imager X Lite user hits Pro-only short-circuit** | Low (Viget uses Pro) | Medium (5xx error) | README documents manual `{ noop: true }` workaround; no runtime detection (kept simple) |
+| **Concurrent generation corrupts cached file** | Low | Medium (broken image until refresh) | Atomic temp-file + rename pattern |
+| **Forged / tampered mock URL** | Low | High (unauthorized generation or disclosure) | HMAC signature (`Security::validateData`) — unforgeable without the app security key; cache filename is `sha1($validatedPayload)`, never raw input, so no path traversal |
+| **Mock used in a real (non-Parts-Kit) template** | Medium | Low (visual only, not security) | By design, images render wherever Parts Kit visibility allows; signed URLs prevent forgery; README states mocks are for Parts Kit templates only and are not a production asset substitute |
+| **Malicious template loops to fill disk via unique hashes** | Low (trusted dev env) | Low (storage/runtime is small) | 5,000-file cap in `MockImageGenerator::generate()`; generation aborts and logs a warning past the threshold |
+| **Long-label DoS via `queryFontMetrics`** | Low | Low | 200-char cap on `MockAssetBuilder::label()` |
+| **File proliferation fills disk** | Low | Low (storage/runtime is small) | `clear-caches/all` integration; documented in README |
+| **`MockAsset` autocomplete misleads authors into calling unsupported methods** | High | Low (clear runtime error) | `@method` PHPDoc on the class; `NotSupportedException` includes method name + README pointer |
+| **CP entry preview can't load mock URLs** | Low | Medium (preview broken for parts-kit-using components) | Verify in Phase 4; URL rule registers on site rules so should work |
+| **Plugin install order issues with Imager X** | Low | Medium (event listener doesn't fire) | `Craft::$app->onInit` deferral already in place ensures Imager X has loaded before our listener registers |
+
+## Resource Requirements
+
+Single-developer implementation. Estimated effort: ~1-2 days for Phases 1-3 with manual verification, plus polish and docs in Phase 4. No infrastructure changes required.
+
+## Future Considerations
+
+Explicitly out of scope for v1 (deferred until a real need surfaces):
+
+- **Background color / text color customization** (`->bgColor`, `->textColor` builder methods)
+- **Format selection** (always PNG in v1; honoring `->format('webp')` later means adding a `format` key to the signed payload, switching the URL extension + `Content-Type`, and branching `MockImageGenerator` — additive, no API break)
+- **Pluggable image generators** (`->generator(callable)` escape hatch for picsum/AI/custom)
+- **Non-image asset kinds** (PDF, video — would require generator branching)
+- **Custom field support** on mocks (`->set('caption', ...)`)
+- **Plugin config knobs** for storage path / URL prefix
+- **Auto-injection of `noop: true` for Imager X Lite** (currently documented-only)
+- **`PartsKitAssetLike` interface** — decouple component code from the Asset hierarchy via a structural interface that both real Assets and MockAssets implement. Requires consumer-project audit (see Phase 4) to determine whether components type-hint on `Asset` or accept duck-typed values.
+
+### Security considerations for v2 additions
+
+When implementing any of the deferred items, watch for these vectors:
+
+- **Pluggable image generators (`->generator(callable)`)** — RCE-shaped surface. Will need an allowlist of registered generator names, or a no-callable-accepted design (only opaque generator IDs registered via config).
+- **Custom field support** — hash inputs must include field values to prevent cache-collision-based pollution.
+- **Plugin config knobs for storage path** — must reject paths outside `@storage` to prevent arbitrary file overwrite via the `rename()` step in `MockImageGenerator`.
+
+Adding any of the above should be possible additively without breaking the v1 API.
+
+## Documentation Plan
+
+- [ ] README.md — new "Mock Assets" section (see Phase 4)
+- [ ] Inline PHPDoc — `@method` block on `MockAsset` listing supported subset
+- [ ] Inline PHPDoc — every public method on `MockAssetBuilder` with example call site
+- [ ] CHANGELOG.md — entry for v[next].0.0 announcing mock asset support and ext-imagick requirement
+- [ ] No separate API docs site — README is the primary reference
+
+## References & Research
+
+### Internal references
+
+- Brainstorm: `docs/brainstorms/2026-05-25-mock-asset-brainstorm.md`
+- Existing services: `src/services/Assets.php:11`, `src/services/Navigation.php:16`
+- Existing controllers: `src/controllers/ViewController.php:17`, `src/controllers/ApiController.php:21`
+- Existing models: `src/models/MockAsset.php:23`, `src/models/MockAssetBuilder.php`, `src/models/Settings.php:7`
+- Plugin entry: `src/Plugin.php` (specifically `_registerUrlRules:122`, `attachEventHandlers:69`, `config():38-46`)
+- Permission registration: `src/Plugin.php:99-112`
+- Existing permission gate (Twig): `src/templates/root.twig:13`
+
+### Craft 5 source references
+
+- `vendor/craftcms/cms/src/elements/Asset.php:1832` — `getImg()` default markup
+- `vendor/craftcms/cms/src/elements/Asset.php:1888` — `getSrcset()` signature
+- `vendor/craftcms/cms/src/elements/Asset.php:2150` — `getUrl()` signature
+- `vendor/craftcms/cms/src/elements/Asset.php:2509` — `getWidth()` typed-union signature (NOT mixed)
+- `vendor/craftcms/cms/src/elements/Asset.php:1076` — `public ?string $alt = null;` (native property since 4.0)
+- `vendor/craftcms/cms/src/elements/Asset.php:1070` — `public ?string $kind = null;` (no getter — direct property)
+- `vendor/craftcms/cms/src/elements/Asset.php:185-207` — `KIND_IMAGE` and related constants
+- `vendor/craftcms/cms/src/helpers/ImageTransforms.php:270` — `normalizeTransform()` for all transform argument shapes
+- `vendor/craftcms/cms/src/helpers/Image.php:90` — `targetDimensions()` for mode-aware dimension resolution
+- `vendor/craftcms/cms/src/utilities/ClearCaches.php:42` — `EVENT_REGISTER_CACHE_OPTIONS` constant
+- `vendor/craftcms/cms/src/web/Response.php:245` — `sendFile()` signature
+
+### Imager X references (Pro license)
+
+- `spacecatninja/craft-imager-x/src/services/ImagerService.php:46` — `EVENT_BEFORE_TRANSFORM_IMAGE` constant
+- `spacecatninja/craft-imager-x/src/events/TransformImageEvent.php` — event payload shape
+- `spacecatninja/craft-imager-x/src/transformers/TransformerInterface.php` — `transform()` contract (not used directly, but mirrors what we return)
+- `spacecatninja/craft-imager-x/src/models/NoopImageModel.php` — reference implementation to mirror for `MockTransformedImage`
+
+### External references
+
+- Craft CMS 5.x docs — Assets: https://craftcms.com/docs/5.x/reference/element-types/assets.html
+- Craft CMS 5.x docs — Controllers: https://craftcms.com/docs/5.x/extend/controllers.html
+- Yii 2 `Security::validateData()` / `hashData()` — HMAC data signing: https://www.yiiframework.com/doc/api/2.0/yii-base-security#validateData()-detail
+- Craft CMS 5.x docs — `hash` Twig filter (HMAC, validated via `craft.app.security.validateData()`): https://craftcms.com/docs/5.x/reference/twig/filters.html#hash
+- Imager X extending: https://imager-x.spacecat.ninja/extending.html
+- Imagick docs — setFont: https://www.php.net/manual/en/imagick.setfont.php
+- Imagick docs — queryFontMetrics: https://www.php.net/manual/en/imagick.queryfontmetrics.php
+
+### Brainstorm decision summary
+
+All decisions from the brainstorm are reflected above. Notable resolved questions:
+
+- Default dimensions: **800×600**
+- Filename default: **auto-generated `mock-{w}x{h}.png`; setting filename derives extension/mimeType**
+- Focal point default: **null; `hasFocalPoint()` returns false**
+- Asset kinds in v1: **image-only**
+- Hash inputs: **width, height, label** (keyed, HMAC-signed payload; no plugin version prefix; rely on clear-caches)
+- Imager X Lite UX: **documented manual workaround only**
+- Plugin config knobs: **hardcoded for v1**

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -13,6 +13,7 @@ use craft\web\twig\variables\CraftVariable;
 use craft\web\UrlManager;
 use craft\web\View;
 use viget\partskit\models\Settings;
+use viget\partskit\services\Assets;
 use viget\partskit\services\Navigation;
 use yii\base\Event;
 
@@ -21,6 +22,8 @@ use yii\base\Event;
  *
  * @method static Plugin getInstance()
  * @method Settings getSettings()
+ * @property-read Navigation $navigation
+ * @property-read Assets $assets
  * @author Viget <craft@viget.com>
  * @copyright Viget
  * @license MIT
@@ -35,9 +38,14 @@ class Plugin extends BasePlugin
 
     public static function config(): array
     {
+        // Convention: every component registered here gets a matching typed
+        // getter AND a `@property-read` line on the class docblock, so it
+        // resolves through both `$plugin->getX()` and the Yii magic property
+        // (the latter is how the `partsKit` Twig variable reaches each service).
         return [
             'components' => [
                 'navigation' => Navigation::class,
+                'assets' => Assets::class,
             ],
         ];
     }
@@ -45,6 +53,11 @@ class Plugin extends BasePlugin
     public function getNavigation(): Navigation
     {
         return $this->get('navigation');
+    }
+
+    public function getAssets(): Assets
+    {
+        return $this->get('assets');
     }
 
     protected function createSettingsModel(): ?Model

--- a/src/models/MockAssetBuilder.php
+++ b/src/models/MockAssetBuilder.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace viget\partskit\models;
+
+/**
+ * Accumulates mock-asset configuration and constructs a {@see MockAsset} in
+ * one().
+ *
+ * Scaffolded in U1 as the return type of
+ * {@see \viget\partskit\services\Assets::make()}. The fluent setters,
+ * configure(), defaults, and the 200-char label cap are added in U3.
+ */
+class MockAssetBuilder
+{
+}

--- a/src/services/Assets.php
+++ b/src/services/Assets.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace viget\partskit\services;
+
+use viget\partskit\models\MockAssetBuilder;
+use yii\base\Component;
+
+/**
+ * Assets service — the entry point for building mock assets from Twig
+ * (`partsKit.assets.make(...)`).
+ *
+ * U1 establishes the service and the make() seam. The Imagick boot check,
+ * config application, and signedUrlForImage() (routing + HMAC signing) land in
+ * U5.
+ */
+class Assets extends Component
+{
+    /**
+     * Returns a builder for a mock asset. Config is applied in U5; for now this
+     * returns an empty builder regardless of the passed config.
+     *
+     * @param array<string, mixed> $config
+     */
+    public function make(array $config = []): MockAssetBuilder
+    {
+        return new MockAssetBuilder();
+    }
+}

--- a/tests/unit/PluginWiringTest.php
+++ b/tests/unit/PluginWiringTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace viget\partskit\tests\unit;
+
+use Codeception\Test\Unit;
+use UnitTester;
+use viget\partskit\Plugin;
+use viget\partskit\services\Assets;
+use viget\partskit\services\Navigation;
+
+/**
+ * Pins the plugin's component wiring: every component registered in
+ * Plugin::config()['components'] must resolve through both its typed getter and
+ * the Yii magic property (the latter is how the `partsKit` Twig variable reaches
+ * the service, e.g. `partsKit.assets.make(...)`).
+ */
+class PluginWiringTest extends Unit
+{
+    protected UnitTester $tester;
+
+    private function plugin(): Plugin
+    {
+        $plugin = Plugin::getInstance();
+        $this->assertNotNull($plugin, 'parts-kit plugin should be installed in the test harness');
+
+        return $plugin;
+    }
+
+    public function testAssetsComponentIsRegistered(): void
+    {
+        $this->assertInstanceOf(Assets::class, $this->plugin()->getAssets());
+    }
+
+    public function testNavigationGetterStillResolves(): void
+    {
+        // Guard against regressing the existing getter while adding the
+        // typed-getter/@property-read convention for `assets`.
+        $this->assertInstanceOf(Navigation::class, $this->plugin()->getNavigation());
+    }
+
+    public function testPartsKitTwigVariableExposesAssets(): void
+    {
+        // The `partsKit` Twig variable is the Plugin instance itself, so
+        // `partsKit.assets` dereferences to the Yii magic property below. This is
+        // the seam the Twig usage `partsKit.assets.make(...)` depends on.
+        $this->assertInstanceOf(Assets::class, $this->plugin()->assets);
+    }
+}

--- a/tests/unit/services/AssetsTest.php
+++ b/tests/unit/services/AssetsTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace viget\partskit\tests\unit\services;
+
+use Codeception\Test\Unit;
+use UnitTester;
+use viget\partskit\models\MockAssetBuilder;
+use viget\partskit\services\Assets;
+
+/**
+ * Assets service. U1 only pins the make() entry point returning a builder;
+ * config application, the Imagick boot check, and signedUrlForImage() arrive in
+ * U5 and extend these cases rather than replacing them.
+ */
+class AssetsTest extends Unit
+{
+    protected UnitTester $tester;
+
+    public function testMakeReturnsBuilder(): void
+    {
+        $this->assertInstanceOf(MockAssetBuilder::class, (new Assets())->make());
+    }
+}


### PR DESCRIPTION
First PR in the Mock Asset feature series (#15). This is the standalone
foundation the plan designates to land before feature work, plus the TDD
rework of the plan itself.

## What's here

**Plan rework (`docs/plans/2026-05-25-feat-mock-asset-service-plan.md`)**
- Restructures the 4 phases into 12 test-first implementation units (U1–U12)
- Adds a Testing Strategy section (unit/functional split, harness affordances,
  the few manual-only items: Imager X Pro AC8, Imagick-absent NFR4)
- Maps every AC/NFR to a concrete Codeception test file
- Reframes Phase 1 as greenfield scaffolding — an audit found the feature is
  entirely unscaffolded (no WIP `MockAsset` to "fix" as the original implied)
- Notes `ext-imagick` is already in CI's `PHP_EXTENSIONS`, so generation tests
  need no workflow change

**U1 — Assets service + plugin wiring**
- Registers an `assets` component with a typed `getAssets()` getter and
  `@property-read`, establishing the convention that every component gets both
- Adds the `make()` seam returning a `MockAssetBuilder` (a minimal stub here;
  fluent setters / `configure()` / defaults arrive in U3, config application
  and URL signing in U5)

## Testing
- `ddev test unit` — 13 tests, 34 assertions pass (4 new wiring/seam tests,
  written test-first; 9 pre-existing, no regressions)
- `ddev phpstan` — clean (level 4)
- `ddev composer check-cs` — clean (ECS)

## Scope notes
- Deliberately foundation-only; U2+ (ext-imagick, builder, element, controller,
  Imager X) land in stacked follow-up PRs.
- `MockAssetBuilder` is intentionally an empty stub at this stage.
