### PR TITLE
[#15] Mock asset core — element, builder, signing, generator, controller (Phase 2)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,8 +7,10 @@
   },
   "require": {
     "php": ">=8.2",
-    "ext-imagick": "*",
     "craftcms/cms": "^5.0.0"
+  },
+  "suggest": {
+    "ext-imagick": "Required to generate mock asset images (partsKit.assets.make()); the rest of the plugin works without it"
   },
   "require-dev": {
     "codeception/codeception": "^5.0.11",

--- a/craft-install/templates/parts-kit/mock-assets/default.twig
+++ b/craft-install/templates/parts-kit/mock-assets/default.twig
@@ -1,0 +1,64 @@
+{#
+  Demo part — Mock Assets.
+
+  Shows the two builder styles and the supported Asset surface rendering real,
+  lazily-generated placeholder PNGs. Dev-harness only (craft-install is
+  export-ignored from the distributed package).
+#}
+{% set hero = craft.partsKit.assets.make({
+  width: 1600,
+  height: 900,
+  label: 'Hero',
+  alt: 'A placeholder hero image',
+}).one %}
+
+{% set thumb = craft.partsKit.assets.make.width(400).height(400).label('Thumb').one %}
+
+{% set card = craft.partsKit.assets.make({ width: 800, height: 600, label: 'Card' }).one %}
+
+<style>
+  .mock-demo { font-family: system-ui, sans-serif; max-width: 880px; margin: 0 auto; padding: 24px; color: #1d2530; }
+  .mock-demo h2 { margin: 32px 0 4px; font-size: 18px; }
+  .mock-demo p.note { color: #5b6675; margin: 0 0 16px; font-size: 14px; }
+  .mock-demo img { display: block; border-radius: 8px; background: #eee; }
+  .mock-demo .row { display: flex; gap: 16px; flex-wrap: wrap; align-items: flex-start; }
+  .mock-demo figure { margin: 0; }
+  .mock-demo figcaption { font: 12px/1.5 ui-monospace, monospace; color: #5b6675; margin-top: 6px; }
+</style>
+
+<div class="mock-demo">
+  <h2>Hero — <code>getImg()</code></h2>
+  <p class="note">1600×900, rendered straight from the mock element.</p>
+  {{ hero.getImg() }}
+
+  <h2>Fit transform — <code>getImg({ width: 640, mode: 'fit' })</code></h2>
+  <p class="note">Native Craft transform math: 1600×900 fit to 640 wide → 640×360.</p>
+  {{ hero.getImg({ width: 640, mode: 'fit' }) }}
+
+  <h2>Responsive — <code>getImg(null, ['1x', '2x'])</code></h2>
+  <p class="note">Each srcset size is a separate signed URL, generated on demand.</p>
+  {{ card.getImg(null, ['1x', '2x']) }}
+
+  <h2>Sizes &amp; labels</h2>
+  <p class="note">Two builder styles; the label is drawn on the placeholder.</p>
+  <div class="row">
+    <figure>
+      <img src="{{ hero.getUrl({ width: 320, height: 180, mode: 'crop' }) }}" alt="" width="320" height="180">
+      <figcaption>make({...}).one · crop 320×180</figcaption>
+    </figure>
+    <figure>
+      {{ thumb.getImg() }}
+      <figcaption>make.width(400).height(400).one</figcaption>
+    </figure>
+  </div>
+
+  <h2>Metadata</h2>
+  <p class="note">A mock answers the parts of the Asset surface templates use.</p>
+  <ul style="font: 13px/1.7 ui-monospace, monospace; color:#333;">
+    <li>hero.alt        → "{{ hero.alt }}"</li>
+    <li>hero.filename   → {{ hero.getFilename() }}</li>
+    <li>hero.extension  → {{ hero.getExtension() }}</li>
+    <li>hero.mimeType   → {{ hero.getMimeType() }}</li>
+    <li>hero.width × height → {{ hero.getWidth() }} × {{ hero.getHeight() }}</li>
+  </ul>
+</div>

--- a/docs/plans/2026-05-25-feat-mock-asset-service-plan.md
+++ b/docs/plans/2026-05-25-feat-mock-asset-service-plan.md
@@ -41,6 +41,14 @@ brainstorm: docs/brainstorms/2026-05-25-mock-asset-brainstorm.md
 >    `RuntimeException` at first use, and the mock route is only reachable via
 >    URLs minted by `make()`, so an Imagick-less site that never uses mocks never
 >    hits a failure path. CI still exercises real Imagick (`PHP_EXTENSIONS`).
+> 2. **Focal point defaults to Craft's center, not null** (supersedes the
+>    brainstorm decision). A real image Asset never returns null from
+>    `getFocalPoint()` — Craft defaults to `['x' => 0.5, 'y' => 0.5]`
+>    (`Asset.php:2690`) — so a null-returning mock silently breaks
+>    `object-position: {{ asset.getFocalPoint(true) }}` parity and crashes
+>    `asset.getFocalPoint().x`. `MockAsset::getFocalPoint()` now mirrors Craft
+>    exactly (null only for non-visual kinds; center default otherwise);
+>    `getHasFocalPoint()` still reports false when unset, matching Craft.
 
 ## Enhancement Summary
 
@@ -326,7 +334,7 @@ The meat. Feature dependencies (U2) land first, then the builder/element/service
 
 **Files:** `src/models/MockAssetBuilder.php` (new), `tests/unit/models/MockAssetBuilderTest.php` (new).
 
-**Approach:** `private array $_config = []`. `configure(array): self` merges and throws `InvalidArgumentException` on unknown keys. Fluent setters `width/height/label/alt/title/filename/focalPoint` each write to `_config` and return `$this`. `label()` trims and rejects > 200 chars. `one(): MockAsset` applies defaults (width 800, height 600 if unset; focalPoint null) and returns `new MockAsset($this->_config)`. The builder does **not** touch a `MockAsset` until `one()`.
+**Approach:** `private array $_config = []`. `configure(array): self` merges and throws `InvalidArgumentException` on unknown keys. Fluent setters `width/height/label/alt/title/filename/focalPoint` each write to `_config` and return `$this`. `label()` trims and rejects > 200 chars. `one(): MockAsset` applies defaults (width 800, height 600 if unset; focalPoint left unset — `MockAsset::getFocalPoint()` supplies Craft's center default) and returns `new MockAsset($this->_config)`. The builder does **not** touch a `MockAsset` until `one()`.
 
 **Patterns to follow:** Yii `new X($config)` idiom; existing model conventions in `src/models/`.
 
@@ -369,7 +377,7 @@ The meat. Feature dependencies (U2) land first, then the builder/element/service
 - `testGetWidthStretchVsFitDiffer` — same inputs, `stretch` vs `fit` produce the documented different dimensions (mode-awareness).
 - `testDefaultFilenameDerivedFromDimensions` — default filename is `mock-800x600.png`; extension `png`, mimeType `image/png`.
 - `testSetFilenameDerivesExtensionAndMime` — `setFilename('hero.jpg')` → extension `jpg`, mimeType `image/jpeg`.
-- `testFocalPointDefaultsToNullAndHasFocalPointFalse` — `getHasFocalPoint()` false, `getFocalPoint()` null by default.
+- `testFocalPointDefaultsToCenterAndHasFocalPointFalse` — `getHasFocalPoint()` false, `getFocalPoint()` returns Craft's center default `{x: 0.5, y: 0.5}` (never null for an image kind). *(Revised 2026-07-09 — was null.)*
 - `testUnsupportedMethodThrowsWithMethodNameAndReadme` — Covers AC10. `getVolume()`/`getFieldValue('caption')` throw `NotSupportedException`; message contains the method name AND `README`.
 
 **Verification:** `composer test-unit` green; static analysis clean (PHPStan must accept the typed-union override).
@@ -752,7 +760,7 @@ Out of scope for v1 (deferred until a real need surfaces):
 
 - Default dimensions: **800×600**
 - Filename default: **auto `mock-{w}x{h}.png`; setting filename derives ext/mimeType**
-- Focal point default: **null; `hasFocalPoint()` false**
+- Focal point default: ~~null; `hasFocalPoint()` false~~ **revised 2026-07-09: Craft's center default `{x: 0.5, y: 0.5}`, mirroring `Asset::getFocalPoint()`; `hasFocalPoint()` still false when unset** (a real image Asset never returns null, so neither can the mock)
 - Asset kinds in v1: **image-only**
 - Hash inputs: **width, height, label** (keyed, HMAC-signed; no version prefix; rely on clear-caches)
 - Imager X Lite UX: **documented manual workaround only**

--- a/docs/plans/2026-05-25-feat-mock-asset-service-plan.md
+++ b/docs/plans/2026-05-25-feat-mock-asset-service-plan.md
@@ -3,7 +3,7 @@ title: Mock Asset Service for Parts Kit
 type: feat
 status: active
 date: 2026-05-25
-revised: 2026-06-08
+revised: 2026-07-09
 brainstorm: docs/brainstorms/2026-05-25-mock-asset-brainstorm.md
 ---
 
@@ -28,6 +28,19 @@ brainstorm: docs/brainstorms/2026-05-25-mock-asset-brainstorm.md
 > authoritative. What changed is *how the work is sequenced and verified*: every
 > feature-bearing unit now leads with a failing test, and the acceptance criteria
 > are mapped to concrete Codeception test files instead of manual verification.
+
+> **2026-07-09 revisions** (from the mid-implementation assessment,
+> `docs/plans/2026-07-09-mock-asset-implementation-assessment.md`):
+>
+> 1. **`ext-imagick` demoted from `require` to `suggest`** (supersedes point 2
+>    above and the original U2 wording). A hard platform requirement would break
+>    `composer update` for every existing 1.x install on an Imagick-less host —
+>    including sites that never use mock assets — and would make the plugin
+>    stricter than Craft core, which accepts GD or Imagick. The runtime guard in
+>    `Assets::make()` is the enforcement point: it throws a clear
+>    `RuntimeException` at first use, and the mock route is only reachable via
+>    URLs minted by `make()`, so an Imagick-less site that never uses mocks never
+>    hits a failure path. CI still exercises real Imagick (`PHP_EXTENSIONS`).
 
 ## Enhancement Summary
 
@@ -140,7 +153,7 @@ Every file below is **new** — confirmed by a 2026-06-08 audit. Each feature-be
 | `src/helpers/MockImageGenerator.php` | Imagick PNG generation invoked only by the controller; atomic write, scale-to-fit, file-count cap | `tests/unit/helpers/MockImageGeneratorTest.php` |
 | `src/controllers/MockController.php` | `actionView(string $token)` — Parts Kit gate, HMAC validation, lazy generation, `sendFile` | `tests/functional/MockControllerCest.php` |
 | `src/resources/fonts/DejaVuSans.ttf` | Bundled font (Bitstream Vera license, redistributable) | covered indirectly by `MockImageGeneratorTest` |
-| `composer.json` *(modify)* | Add `"ext-imagick": "*"` to `require` | `composer validate` |
+| `composer.json` *(modify)* | Declare `ext-imagick` in `suggest` (runtime guard in `Assets::make()` enforces it at first use — see 2026-07-09 revision) | `composer validate` |
 | `README.md` / `CHANGELOG.md` *(modify)* | Document Mock Asset API, Imager X behavior, supported surface | n/a (docs) |
 
 ### Output Structure
@@ -267,17 +280,17 @@ The meat. Feature dependencies (U2) land first, then the builder/element/service
 
 #### U2. Feature dependencies — `ext-imagick`, bundled font
 
-**✅ Status: Done** (commit `3e3700b`, PR [#25](https://github.com/vigetlabs/craft-parts-kit/pull/25), stacked on #24) — `ext-imagick` required, DejaVu Sans 2.37 + `LICENSE` bundled, `*.ttf binary` added to `.gitattributes`. Full font provenance, checksums, and license-compliance analysis recorded below.
+**✅ Status: Done** (commit `3e3700b`, PR [#25](https://github.com/vigetlabs/craft-parts-kit/pull/25), stacked on #24) — `ext-imagick` declared, DejaVu Sans 2.37 + `LICENSE` bundled, `*.ttf binary` added to `.gitattributes`. Full font provenance, checksums, and license-compliance analysis recorded below. **Revised 2026-07-09:** `ext-imagick` moved from `require` to `suggest` — the hard requirement would have broken `composer update` for existing installs that never use mocks; the `Assets::make()` runtime guard (U5) is the enforcement point instead. See the revision note at the top of this plan.
 
-**Goal:** Declare the Imagick requirement and ship the fallback font so generation works on slim images.
+**Goal:** Declare the Imagick dependency (as a `suggest` + runtime guard) and ship the fallback font so generation works on slim images.
 
 **Requirements:** Prerequisite for U7 (generation) and AC2.
 
 **Dependencies:** none (can land alongside U1).
 
-**Files:** `composer.json` (add `"ext-imagick": "*"` to `require`), `src/resources/fonts/DejaVuSans.ttf` (new binary), `src/resources/fonts/LICENSE` (new — the font's license text, required for redistribution), `.gitattributes` (add `*.ttf binary`).
+**Files:** `composer.json` (add `ext-imagick` to `suggest`), `src/resources/fonts/DejaVuSans.ttf` (new binary), `src/resources/fonts/LICENSE` (new — the font's license text, required for redistribution), `.gitattributes` (add `*.ttf binary`).
 
-**Approach:** Add the extension constraint to `require`. Add the TTF under `src/resources/fonts/` — covered by the existing PSR-4-adjacent package contents (verify it is **not** matched by any `export-ignore` rule in `.gitattributes`, since `docs/`, `craft-install/`, `.ddev/` are stripped from the dist package). The repo's `.gitattributes` has a `* text=auto` rule that would LF-normalize (corrupt) a binary font on checkout, so add an explicit `*.ttf binary` rule. **No CI workflow change is needed** — `imagick` is already in `PHP_EXTENSIONS` in both `.github/workflows/ci.yml` and `codecept.yml`.
+**Approach:** Declare the extension in `suggest` so Composer surfaces it without imposing a platform requirement on consumers who never use mock assets; `Assets::make()` (U5) throws a clear `RuntimeException` when it's actually needed and missing. Add the TTF under `src/resources/fonts/` — covered by the existing PSR-4-adjacent package contents (verify it is **not** matched by any `export-ignore` rule in `.gitattributes`, since `docs/`, `craft-install/`, `.ddev/` are stripped from the dist package). The repo's `.gitattributes` has a `* text=auto` rule that would LF-normalize (corrupt) a binary font on checkout, so add an explicit `*.ttf binary` rule. **No CI workflow change is needed** — `imagick` is already in `PHP_EXTENSIONS` in both `.github/workflows/ci.yml` and `codecept.yml`.
 
 **Font provenance & license (logged for audit — resolved during U2 execution on 2026-06-08):**
 
@@ -563,7 +576,7 @@ Soft dependency. Pro enables transparent integration; Lite gets a documented man
 
 **Files:** `README.md` (modify), `CHANGELOG.md` (modify).
 
-**Approach:** New "Mock Assets" README section with the Twig examples, the supported-`Asset`-surface table (and what throws), the Imager X Pro/Lite matrix incl. the manual `{ noop: true }` workaround, the visibility note (mirrors Parts Kit; HMAC-signed; tampered → 404; dev-only intent), the `clear-caches/all` note, and the file-proliferation/5,000-cap note. CHANGELOG entry announcing mock assets + the `ext-imagick` requirement. Verify every `NotSupportedException` message names the method and points to README. Audit one or two Viget consumer projects for `Asset $param` type-hints and record findings in the PR. Manually verify CP entry-preview context renders mock URLs.
+**Approach:** New "Mock Assets" README section with the Twig examples, the supported-`Asset`-surface table (and what throws), the Imager X Pro/Lite matrix incl. the manual `{ noop: true }` workaround, the visibility note (mirrors Parts Kit; HMAC-signed; tampered → 404; dev-only intent), the `clear-caches/all` note, and the file-proliferation/5,000-cap note. CHANGELOG entry announcing mock assets + the `ext-imagick` runtime dependency for mocks (suggested in Composer, enforced by the `make()` guard). Verify every `NotSupportedException` message names the method and points to README. Audit one or two Viget consumer projects for `Asset $param` type-hints and record findings in the PR. Manually verify CP entry-preview context renders mock URLs.
 
 **Patterns to follow:** existing `README.md` structure; `craft-viget-base-testing-reference` for doc conventions.
 
@@ -685,7 +698,7 @@ Out of scope for v1 (deferred until a real need surfaces):
 ## Dependencies & Prerequisites
 
 - PHP 8.2+ and Craft CMS 5.0+ (already required).
-- PHP `ext-imagick` (newly required — added to `composer.json`; already present in CI `PHP_EXTENSIONS`).
+- PHP `ext-imagick` (suggested in `composer.json`, not required — the `Assets::make()` runtime guard enforces it at first use; already present in CI `PHP_EXTENSIONS`). *(Revised 2026-07-09 — was a hard `require`.)*
 - Bundled DejaVu Sans TTF + its `LICENSE` (`src/resources/fonts/`). DejaVu **2.37**, sourced byte-for-byte from the official `dejavu-fonts` GitHub release, Bitstream Vera + Arev license (redistributable inside a larger package). Full provenance, checksums, and license-compliance analysis recorded in **U2** above.
 - Codeception suite (unit + functional through `\craft\test\Craft`), PHPStan level 4, ECS — all already wired and CI-enforced.
 - **Optional:** Imager X Pro for transparent integration (soft dependency via `class_exists`; not in dev deps).

--- a/docs/plans/2026-05-25-feat-mock-asset-service-plan.md
+++ b/docs/plans/2026-05-25-feat-mock-asset-service-plan.md
@@ -212,19 +212,19 @@ Units carry stable U-IDs and are grouped into the original four phases. Phases 1
 
 ### Implementation Status
 
-> Authoritative progress lives in git/PRs; this table is a convenience snapshot, last updated **2026-06-09**.
+> Authoritative progress lives in git/PRs; this table is a convenience snapshot, last updated **2026-06-11**.
 
 | Unit | Status | Branch / PR | Notes |
 |---|---|---|---|
 | U1 | ✅ Done | `jp/15-asset-mock-feature` → [#24](https://github.com/vigetlabs/craft-parts-kit/pull/24) (draft) | Commit `109fccc`. Tests + PHPStan + ECS green. |
 | U2 | ✅ Done | `jp/15-asset-mock-deps` → [#25](https://github.com/vigetlabs/craft-parts-kit/pull/25) (draft, stacked on #24) | Commit `3e3700b`. Font provenance/license logged in U2. |
-| U3 | ⬜ Not started | — | `MockAssetBuilder` (next up). |
-| U4 | ⬜ Not started | — | `MockAsset` surface + dimensions + guards. |
-| U5 | ⬜ Not started | — | `Assets::make()` + `signedUrlForImage()` + Imagick check. |
-| U6 | ⬜ Not started | — | `MockAsset` transform-emitting methods. |
-| U7 | ⬜ Not started | — | `MockImageGenerator` helper. |
-| U8 | ⬜ Not started | — | `MockController` + URL rule. |
-| U9 | ⬜ Not started | — | ClearCaches integration. |
+| U3 | ✅ Done | `jp/15-asset-mock-core` (Phase 2 PR pending) | Landed with U4 (commit `9d90e8d`); dimension bounds added in review. |
+| U4 | ✅ Done | `jp/15-asset-mock-core` | Commit `9d90e8d`. Surface + dimensions + `NotSupportedException` guards. |
+| U5 | ✅ Done | `jp/15-asset-mock-core` | Commit `a6a89b1`. `make()` + `signedUrlForImage()` + Imagick check. |
+| U6 | ✅ Done | `jp/15-asset-mock-core` | Commit `0acad7e`. Transform-emitting URL methods. |
+| U7 | ✅ Done | `jp/15-asset-mock-core` | Commit `61e1f56`. Generator + atomic write + 5,000-file cap. |
+| U8 | ✅ Done | `jp/15-asset-mock-core` | Commit `e4e64a6`. Controller + signed URL rule + gate-before-validation. |
+| U9 | ✅ Done | `jp/15-asset-mock-core` | Commit `f2cc3b8`. ClearCaches integration. |
 | U10 | ⬜ Not started | — | `MockTransformedImage` model. |
 | U11 | ⬜ Not started | — | `ImagerXIntegration` service + registration. |
 | U12 | ⬜ Not started | — | README, CHANGELOG, consumer audit, final checks. |

--- a/docs/plans/2026-05-25-feat-mock-asset-service-plan.md
+++ b/docs/plans/2026-05-25-feat-mock-asset-service-plan.md
@@ -210,11 +210,32 @@ Every feature-bearing unit below carries `Execution note: test-first` — write 
 
 Units carry stable U-IDs and are grouped into the original four phases. Phases 1–4 map to PRs in order; within a phase, follow the dependency order.
 
+### Implementation Status
+
+> Authoritative progress lives in git/PRs; this table is a convenience snapshot, last updated **2026-06-09**.
+
+| Unit | Status | Branch / PR | Notes |
+|---|---|---|---|
+| U1 | ✅ Done | `jp/15-asset-mock-feature` → [#24](https://github.com/vigetlabs/craft-parts-kit/pull/24) (draft) | Commit `109fccc`. Tests + PHPStan + ECS green. |
+| U2 | ✅ Done | `jp/15-asset-mock-deps` → [#25](https://github.com/vigetlabs/craft-parts-kit/pull/25) (draft, stacked on #24) | Commit `3e3700b`. Font provenance/license logged in U2. |
+| U3 | ⬜ Not started | — | `MockAssetBuilder` (next up). |
+| U4 | ⬜ Not started | — | `MockAsset` surface + dimensions + guards. |
+| U5 | ⬜ Not started | — | `Assets::make()` + `signedUrlForImage()` + Imagick check. |
+| U6 | ⬜ Not started | — | `MockAsset` transform-emitting methods. |
+| U7 | ⬜ Not started | — | `MockImageGenerator` helper. |
+| U8 | ⬜ Not started | — | `MockController` + URL rule. |
+| U9 | ⬜ Not started | — | ClearCaches integration. |
+| U10 | ⬜ Not started | — | `MockTransformedImage` model. |
+| U11 | ⬜ Not started | — | `ImagerXIntegration` service + registration. |
+| U12 | ⬜ Not started | — | README, CHANGELOG, consumer audit, final checks. |
+
 ### Phase 1 — Foundation scaffolding (separate PR)
 
 A small, mergeable-on-its-own PR establishing the `Assets` service seam and the component-getter convention. Reframed from the original "cleanup" framing because **no WIP code exists to fix** — this is greenfield scaffolding that lets Phase 2 build on a registered service.
 
 #### U1. `Assets` service skeleton + Plugin wiring
+
+**✅ Status: Done** (commit `109fccc`, PR [#24](https://github.com/vigetlabs/craft-parts-kit/pull/24)) — all test scenarios implemented and green; PHPStan + ECS clean. `MockAssetBuilder` landed here as a minimal stub (anticipated below) so `make()` has a real return type; U3 fleshes it out.
 
 **Goal:** A registered `assets` component reachable as `Plugin::getInstance()->getAssets()` and as the `partsKit.assets` Twig accessor, plus the typed-getter/`@property-read` convention applied to every component.
 
@@ -245,6 +266,8 @@ A small, mergeable-on-its-own PR establishing the `Assets` service seam and the 
 The meat. Feature dependencies (U2) land first, then the builder/element/service/generator/controller in dependency order.
 
 #### U2. Feature dependencies — `ext-imagick`, bundled font
+
+**✅ Status: Done** (commit `3e3700b`, PR [#25](https://github.com/vigetlabs/craft-parts-kit/pull/25), stacked on #24) — `ext-imagick` required, DejaVu Sans 2.37 + `LICENSE` bundled, `*.ttf binary` added to `.gitattributes`. Full font provenance, checksums, and license-compliance analysis recorded below.
 
 **Goal:** Declare the Imagick requirement and ship the fallback font so generation works on slim images.
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -133,6 +133,11 @@ class Plugin extends BasePlugin
     {
         $partsKitDir = $this->getSettings()->directory;
         $event->rules[$partsKitDir] = 'parts-kit/view/root';
+        // Must precede the greedy `<template:.+>` catch-all below, which would
+        // otherwise swallow `/mock/<token>.png` and route it to view/template.
+        // Plain `.png` — Yii's UrlRule escapes literal dots itself, so a
+        // hand-escaped `\.png` would become `\\.png` and never match.
+        $event->rules[$partsKitDir . '/mock/<token:[A-Za-z0-9_-]+>.png'] = 'parts-kit/mock/view';
         $event->rules[$partsKitDir . '/<template:.+>'] = 'parts-kit/view/template';
     }
 }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -132,7 +132,7 @@ class Plugin extends BasePlugin
                 $event->options[] = [
                     'key' => 'parts-kit-mocks',
                     'label' => Craft::t('parts-kit', 'Parts Kit mock images'),
-                    'action' => Craft::getAlias('@storage/runtime/parts-kit-mocks'),
+                    'action' => Craft::getAlias(Assets::CACHE_DIRECTORY),
                 ];
             }
         );

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -5,10 +5,12 @@ namespace viget\partskit;
 use Craft;
 use craft\base\Model;
 use craft\base\Plugin as BasePlugin;
+use craft\events\RegisterCacheOptionsEvent;
 use craft\events\RegisterTemplateRootsEvent;
 use craft\events\RegisterUrlRulesEvent;
 use craft\events\RegisterUserPermissionsEvent;
 use craft\services\UserPermissions;
+use craft\utilities\ClearCaches;
 use craft\web\twig\variables\CraftVariable;
 use craft\web\UrlManager;
 use craft\web\View;
@@ -117,6 +119,20 @@ class Plugin extends BasePlugin
                             'label' => 'View Parts Kit',
                         ],
                     ],
+                ];
+            }
+        );
+
+        // Let `clear-caches/all` (and the CP Clear Caches utility) empty the
+        // lazily-generated mock image cache.
+        Event::on(
+            ClearCaches::class,
+            ClearCaches::EVENT_REGISTER_CACHE_OPTIONS,
+            static function(RegisterCacheOptionsEvent $event) {
+                $event->options[] = [
+                    'key' => 'parts-kit-mocks',
+                    'label' => Craft::t('parts-kit', 'Parts Kit mock images'),
+                    'action' => Craft::getAlias('@storage/runtime/parts-kit-mocks'),
                 ];
             }
         );

--- a/src/controllers/MockController.php
+++ b/src/controllers/MockController.php
@@ -42,7 +42,7 @@ class MockController extends Controller
         $payload = Craft::$app->getSecurity()->validateData(StringHelper::base64UrlDecode($token));
 
         if ($payload === false) {
-            throw new NotFoundHttpException('Mock image not found.');
+            throw $this->_notFound();
         }
 
         $config = Json::decode($payload);
@@ -58,7 +58,7 @@ class MockController extends Controller
             || $width > MockImageGenerator::MAX_DIMENSION
             || $height > MockImageGenerator::MAX_DIMENSION
         ) {
-            throw new NotFoundHttpException('Mock image not found.');
+            throw $this->_notFound();
         }
 
         $path = Plugin::getInstance()->getAssets()->cachePathForPayload($payload);
@@ -70,7 +70,7 @@ class MockController extends Controller
         // Generation may no-op at the file-count cap; treat a still-missing file
         // as a normal miss rather than failing the response.
         if (!file_exists($path)) {
-            throw new NotFoundHttpException('Mock image not found.');
+            throw $this->_notFound();
         }
 
         // A plain raw-content response (not sendFile/sendContentAsFile): the
@@ -84,7 +84,7 @@ class MockController extends Controller
         // concurrent clear-caches). Treat it as a miss rather than serving an
         // empty-body 200.
         if ($bytes === false) {
-            throw new NotFoundHttpException('Mock image not found.');
+            throw $this->_notFound();
         }
 
         $response = $this->response;
@@ -96,5 +96,15 @@ class MockController extends Controller
         $response->content = $bytes;
 
         return $response;
+    }
+
+    /**
+     * Every failure mode — invalid signature, out-of-range dimensions, cap-
+     * aborted generation, vanished file — answers with this same uniform 404 so
+     * the response never leaks which check failed.
+     */
+    private function _notFound(): NotFoundHttpException
+    {
+        return new NotFoundHttpException('Mock image not found.');
     }
 }

--- a/src/controllers/MockController.php
+++ b/src/controllers/MockController.php
@@ -46,9 +46,20 @@ class MockController extends Controller
         }
 
         $config = Json::decode($payload);
-        $width = (int)$config['w'];
-        $height = (int)$config['h'];
+        $width = (int)($config['w'] ?? 0);
+        $height = (int)($config['h'] ?? 0);
         $label = $config['label'] ?? null;
+
+        // Defense in depth: the builder bounds dimensions at mint time, but a
+        // transform or a directly-built URL could still carry an out-of-range
+        // size. Reject it before it reaches Imagick's canvas allocation.
+        if (
+            $width < 1 || $height < 1
+            || $width > MockImageGenerator::MAX_DIMENSION
+            || $height > MockImageGenerator::MAX_DIMENSION
+        ) {
+            throw new NotFoundHttpException('Mock image not found.');
+        }
 
         $path = Plugin::getInstance()->getAssets()->cachePathForPayload($payload);
 
@@ -67,13 +78,22 @@ class MockController extends Controller
         // sends headers mid-request, which the functional connector can't drive.
         // Serving the bytes as response content keeps the same observable result
         // (image/png body + immutable cache) and stays testable.
+        $bytes = file_get_contents($path);
+
+        // The file vanished between the existence check and the read (e.g. a
+        // concurrent clear-caches). Treat it as a miss rather than serving an
+        // empty-body 200.
+        if ($bytes === false) {
+            throw new NotFoundHttpException('Mock image not found.');
+        }
+
         $response = $this->response;
         $response->format = Response::FORMAT_RAW;
         $response->getHeaders()
             ->set('Content-Type', 'image/png')
             ->set('Content-Disposition', 'inline; filename="mock.png"')
             ->set('Cache-Control', 'public, max-age=31536000, immutable');
-        $response->content = (string)file_get_contents($path);
+        $response->content = $bytes;
 
         return $response;
     }

--- a/src/controllers/MockController.php
+++ b/src/controllers/MockController.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace viget\partskit\controllers;
+
+use Craft;
+use craft\helpers\Json;
+use craft\web\Controller;
+use viget\partskit\helpers\MockImageGenerator;
+use viget\partskit\Plugin;
+use yii\helpers\StringHelper;
+use yii\web\NotFoundHttpException;
+use yii\web\Response;
+
+/**
+ * Serves the placeholder PNGs referenced by {@see \viget\partskit\models\MockAsset}
+ * URLs.
+ *
+ * The route token is an HMAC-signed, base64url JSON payload (`{w, h, label}`).
+ * Each request: enforces the Parts Kit visibility gate **first** (so an
+ * unauthorized request gets a uniform 403 and cannot probe which tokens are
+ * valid), then validates the signature (tamper → 404), then lazily generates the
+ * PNG on a cache miss and serves it with a long immutable cache header.
+ */
+class MockController extends Controller
+{
+    protected array|int|bool $allowAnonymous = ['view'];
+
+    /**
+     * actions/parts-kit/mock/view — `{directory}/mock/<token>.png`
+     *
+     * @see Plugin::_registerUrlRules()
+     */
+    public function actionView(string $token): Response
+    {
+        // Gate before any token work: visibility mirrors Parts Kit, and running
+        // the permission check first means a forged token never reveals whether
+        // it would have validated (no oracle).
+        if (Plugin::getInstance()->getSettings()->requireViewPermission) {
+            $this->requirePermission('parts-kit:view');
+        }
+
+        $payload = Craft::$app->getSecurity()->validateData(StringHelper::base64UrlDecode($token));
+
+        if ($payload === false) {
+            throw new NotFoundHttpException('Mock image not found.');
+        }
+
+        $config = Json::decode($payload);
+        $width = (int)$config['w'];
+        $height = (int)$config['h'];
+        $label = $config['label'] ?? null;
+
+        // The on-disk name is the hash of the validated payload — never raw
+        // input — so there is no path-traversal surface.
+        $path = Craft::getAlias('@storage/runtime/parts-kit-mocks/') . sha1($payload) . '.png';
+
+        if (!file_exists($path)) {
+            MockImageGenerator::generate($path, $width, $height, $label);
+        }
+
+        // Generation may no-op at the file-count cap; treat a still-missing file
+        // as a normal miss rather than failing the response.
+        if (!file_exists($path)) {
+            throw new NotFoundHttpException('Mock image not found.');
+        }
+
+        // A plain raw-content response (not sendFile/sendContentAsFile): the
+        // placeholder PNGs are tiny, and a streamed/flushed download response
+        // sends headers mid-request, which the functional connector can't drive.
+        // Serving the bytes as response content keeps the same observable result
+        // (image/png body + immutable cache) and stays testable.
+        $response = $this->response;
+        $response->format = Response::FORMAT_RAW;
+        $response->getHeaders()
+            ->set('Content-Type', 'image/png')
+            ->set('Content-Disposition', 'inline; filename="mock.png"')
+            ->set('Cache-Control', 'public, max-age=31536000, immutable');
+        $response->content = (string)file_get_contents($path);
+
+        return $response;
+    }
+}

--- a/src/controllers/MockController.php
+++ b/src/controllers/MockController.php
@@ -50,9 +50,7 @@ class MockController extends Controller
         $height = (int)$config['h'];
         $label = $config['label'] ?? null;
 
-        // The on-disk name is the hash of the validated payload — never raw
-        // input — so there is no path-traversal surface.
-        $path = Craft::getAlias('@storage/runtime/parts-kit-mocks/') . sha1($payload) . '.png';
+        $path = Plugin::getInstance()->getAssets()->cachePathForPayload($payload);
 
         if (!file_exists($path)) {
             MockImageGenerator::generate($path, $width, $height, $label);

--- a/src/helpers/MockImageGenerator.php
+++ b/src/helpers/MockImageGenerator.php
@@ -43,17 +43,6 @@ class MockImageGenerator
     private const TEXT_FIT_RATIO = 0.9;
 
     /**
-     * Font fallback chain: bundled DejaVu Sans, then the common Linux/Docker
-     * system path, then macOS Helvetica for local dev. Throws if none resolve.
-     *
-     * @var list<string>
-     */
-    private const FONT_CANDIDATES = [
-        '/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf',
-        '/System/Library/Fonts/Helvetica.ttc',
-    ];
-
-    /**
      * Generates a PNG of exactly {@param $width}×{@param $height} at the given
      * path, with a centered, scaled-to-fit label (defaulting to the dimensions).
      * The write is atomic. No-ops (with a warning) if the directory already
@@ -141,7 +130,15 @@ class MockImageGenerator
 
     private static function resolveFont(): string
     {
-        foreach (self::fontCandidates() as $candidate) {
+        // Bundled DejaVu Sans first, then the common Linux/Docker system path,
+        // then macOS Helvetica for local dev.
+        $candidates = [
+            dirname(__DIR__) . '/resources/fonts/DejaVuSans.ttf',
+            '/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf',
+            '/System/Library/Fonts/Helvetica.ttc',
+        ];
+
+        foreach ($candidates as $candidate) {
             if (is_file($candidate)) {
                 return $candidate;
             }
@@ -151,16 +148,5 @@ class MockImageGenerator
             'Parts Kit could not find a usable font for mock image generation. '
             . 'The bundled DejaVuSans.ttf is missing and no system fallback was found. See README.',
         );
-    }
-
-    /**
-     * @return list<string>
-     */
-    private static function fontCandidates(): array
-    {
-        return [
-            dirname(__DIR__) . '/resources/fonts/DejaVuSans.ttf',
-            ...self::FONT_CANDIDATES,
-        ];
     }
 }

--- a/src/helpers/MockImageGenerator.php
+++ b/src/helpers/MockImageGenerator.php
@@ -1,0 +1,166 @@
+<?php
+
+namespace viget\partskit\helpers;
+
+use Craft;
+use craft\helpers\FileHelper;
+use Imagick;
+use ImagickDraw;
+use ImagickPixel;
+use RuntimeException;
+
+/**
+ * Generates the placeholder PNGs served by
+ * {@see \viget\partskit\controllers\MockController}.
+ *
+ * This is the **only** image-generation path in the plugin, and it is invoked
+ * only by the controller on a cache miss — never at template-render time. It is
+ * a stateless static helper (its own namespace + isolation aid testability: the
+ * generator is directly callable with a temp path and asserted via
+ * `getimagesize()`).
+ *
+ * Writes are atomic (temp file + `rename()`) so a concurrent first request can
+ * never observe a half-written PNG, and generation is bounded by a file-count
+ * cap so a hostile template can't fill the cache directory unboundedly.
+ */
+class MockImageGenerator
+{
+    /**
+     * Hard ceiling on cached PNGs in the target directory. Past this, generation
+     * aborts (a missing file then reads as a normal cache miss to the caller).
+     */
+    public const MAX_FILES = 5000;
+
+    private const BACKGROUND_COLOR = '#999999';
+
+    private const TEXT_COLOR = '#ffffff';
+
+    private const MIN_FONT_SIZE = 8;
+
+    /**
+     * Fraction of the canvas the label must fit within (per axis).
+     */
+    private const TEXT_FIT_RATIO = 0.9;
+
+    /**
+     * Font fallback chain: bundled DejaVu Sans, then the common Linux/Docker
+     * system path, then macOS Helvetica for local dev. Throws if none resolve.
+     *
+     * @var list<string>
+     */
+    private const FONT_CANDIDATES = [
+        '/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf',
+        '/System/Library/Fonts/Helvetica.ttc',
+    ];
+
+    /**
+     * Generates a PNG of exactly {@param $width}×{@param $height} at the given
+     * path, with a centered, scaled-to-fit label (defaulting to the dimensions).
+     * The write is atomic. No-ops (with a warning) if the directory already
+     * holds {@see MAX_FILES} PNGs.
+     *
+     * @throws RuntimeException if no usable font is found
+     */
+    public static function generate(string $path, int $width, int $height, ?string $label): void
+    {
+        $directory = dirname($path);
+        FileHelper::createDirectory($directory);
+
+        if (count(glob($directory . '/*.png') ?: []) >= self::MAX_FILES) {
+            Craft::warning(
+                sprintf(
+                    'Parts Kit mock image cache hit the %d-file cap; skipping generation for %s.',
+                    self::MAX_FILES,
+                    basename($path),
+                ),
+                __METHOD__,
+            );
+
+            return;
+        }
+
+        $text = ($label !== null && $label !== '') ? $label : "{$width}x{$height}";
+        $font = self::resolveFont();
+
+        $image = new Imagick();
+        $image->newImage($width, $height, new ImagickPixel(self::BACKGROUND_COLOR), 'png');
+
+        $draw = new ImagickDraw();
+        $draw->setFillColor(new ImagickPixel(self::TEXT_COLOR));
+        $draw->setFont($font);
+        $draw->setGravity(Imagick::GRAVITY_CENTER);
+
+        $fontSize = self::fitFontSize($image, $draw, $text, $width, $height);
+        $draw->setFontSize($fontSize);
+
+        $image->annotateImage($draw, 0, 0, 0, $text);
+
+        $image->setImageFormat('png');
+        $image->setImageCompressionQuality(75);
+        $image->stripImage();
+
+        // Atomic write: a concurrent reader sees either no file or the complete
+        // PNG, never a partial one.
+        $tempPath = $path . '.tmp.' . bin2hex(random_bytes(8));
+        $image->writeImage($tempPath);
+        rename($tempPath, $path);
+
+        $draw->clear();
+        $image->clear();
+    }
+
+    /**
+     * Steps the font size down from ~20% of the smaller edge until the label
+     * fits within {@see TEXT_FIT_RATIO} of both axes, flooring at
+     * {@see MIN_FONT_SIZE} so tiny canvases still get a positive point size.
+     */
+    private static function fitFontSize(
+        Imagick $image,
+        ImagickDraw $draw,
+        string $text,
+        int $width,
+        int $height,
+    ): int {
+        $size = max(self::MIN_FONT_SIZE, (int)(min($width, $height) * 0.2));
+        $maxWidth = $width * self::TEXT_FIT_RATIO;
+        $maxHeight = $height * self::TEXT_FIT_RATIO;
+
+        while ($size > self::MIN_FONT_SIZE) {
+            $draw->setFontSize($size);
+            $metrics = $image->queryFontMetrics($draw, $text);
+
+            if ($metrics['textWidth'] <= $maxWidth && $metrics['textHeight'] <= $maxHeight) {
+                break;
+            }
+
+            $size--;
+        }
+
+        return $size;
+    }
+
+    private static function resolveFont(): string
+    {
+        foreach (self::fontCandidates() as $candidate) {
+            if (is_file($candidate)) {
+                return $candidate;
+            }
+        }
+
+        throw new RuntimeException(
+            'Parts Kit could not find a usable font for mock image generation. '
+            . 'The bundled DejaVuSans.ttf is missing and no system fallback was found. See README.',
+        );
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function fontCandidates(): array
+    {
+        return [
+            dirname(__DIR__) . '/resources/fonts/DejaVuSans.ttf',
+            ...self::FONT_CANDIDATES,
+        ];
+    }
+}

--- a/src/helpers/MockImageGenerator.php
+++ b/src/helpers/MockImageGenerator.php
@@ -31,6 +31,14 @@ class MockImageGenerator
      */
     public const MAX_FILES = 5000;
 
+    /**
+     * Hard ceiling per axis. A placeholder never needs to be larger, and the
+     * bound keeps a stray (or hostile) dimension from allocating an enormous
+     * Imagick canvas. The builder rejects out-of-range dimensions up front; the
+     * controller re-checks the decoded token as defense in depth.
+     */
+    public const MAX_DIMENSION = 5000;
+
     private const BACKGROUND_COLOR = '#999999';
 
     private const TEXT_COLOR = '#ffffff';
@@ -89,13 +97,29 @@ class MockImageGenerator
         $image->stripImage();
 
         // Atomic write: a concurrent reader sees either no file or the complete
-        // PNG, never a partial one.
+        // PNG, never a partial one. On any failure, remove the temp file so a
+        // half-written artifact never lingers (it would also be invisible to the
+        // *.png file-count cap).
         $tempPath = $path . '.tmp.' . bin2hex(random_bytes(8));
-        $image->writeImage($tempPath);
-        rename($tempPath, $path);
 
-        $draw->clear();
-        $image->clear();
+        try {
+            $image->writeImage($tempPath);
+
+            if (!rename($tempPath, $path)) {
+                throw new RuntimeException(
+                    'Failed to move the generated mock image into place: ' . basename($path),
+                );
+            }
+        } catch (\Throwable $e) {
+            if (is_file($tempPath)) {
+                @unlink($tempPath);
+            }
+
+            throw $e;
+        } finally {
+            $draw->clear();
+            $image->clear();
+        }
     }
 
     /**

--- a/src/models/MockAsset.php
+++ b/src/models/MockAsset.php
@@ -6,6 +6,7 @@ use craft\base\FsInterface;
 use craft\elements\Asset;
 use craft\elements\User;
 use craft\helpers\Assets as AssetsHelper;
+use craft\helpers\FileHelper;
 use craft\helpers\Html;
 use craft\helpers\Image;
 use craft\helpers\ImageTransforms;
@@ -40,20 +41,6 @@ use yii\helpers\ArrayHelper;
  */
 class MockAsset extends Asset
 {
-    /**
-     * Extension → MIME map for the handful of image formats a mock filename may
-     * carry. Anything else falls back to `image/png`.
-     */
-    private const MIME_TYPES = [
-        'png' => 'image/png',
-        'jpg' => 'image/jpeg',
-        'jpeg' => 'image/jpeg',
-        'gif' => 'image/gif',
-        'webp' => 'image/webp',
-        'avif' => 'image/avif',
-        'svg' => 'image/svg+xml',
-    ];
-
     private ?int $_width = null;
 
     private ?int $_height = null;
@@ -83,11 +70,7 @@ class MockAsset extends Asset
         $this->_width = ArrayHelper::remove($config, 'width');
         $this->_height = ArrayHelper::remove($config, 'height');
         $this->_label = ArrayHelper::remove($config, 'label');
-
-        $filename = ArrayHelper::remove($config, 'filename');
-        if ($filename !== null) {
-            $this->_filename = $filename;
-        }
+        $this->_filename = ArrayHelper::remove($config, 'filename');
 
         /** @var array{x: float, y: float}|null $focalPoint */
         $focalPoint = ArrayHelper::remove($config, 'focalPoint');
@@ -148,10 +131,13 @@ class MockAsset extends Asset
             return null;
         }
 
+        // Resolve dimensions once for the width/height attributes.
+        [$width, $height] = $this->_resolveDimensions($transform);
+
         $img = Html::tag('img', '', [
             'src' => $url,
-            'width' => $this->getWidth($transform),
-            'height' => $this->getHeight($transform),
+            'width' => $width,
+            'height' => $height,
             'srcset' => $sizes ? $this->getSrcset($sizes, $transform) : false,
             'alt' => $this->alt,
         ]);
@@ -159,22 +145,9 @@ class MockAsset extends Asset
         return Template::raw($img);
     }
 
-    public function getSrcset(array $sizes, mixed $transform = null): string|false
-    {
-        $urls = array_filter($this->getUrlsBySize($sizes, $transform));
-
-        if (empty($urls)) {
-            return false;
-        }
-
-        $srcset = [];
-
-        foreach ($urls as $size => $url) {
-            $srcset[] = $size === '1x' ? $url : "$url $size";
-        }
-
-        return implode(', ', $srcset);
-    }
+    // getSrcset() is inherited from Asset: its body is just
+    // `array_filter($this->getUrlsBySize(...))` formatted into a srcset string,
+    // and getUrlsBySize() is overridden below to emit signed mock URLs.
 
     /**
      * @param string[] $sizes
@@ -260,7 +233,7 @@ class MockAsset extends Asset
 
     public function getMimeType(mixed $transform = null): ?string
     {
-        return self::MIME_TYPES[$this->getExtension()] ?? 'image/png';
+        return FileHelper::getMimeTypeByExtension($this->getFilename()) ?? 'image/png';
     }
 
     public function getHasFocalPoint(): bool

--- a/src/models/MockAsset.php
+++ b/src/models/MockAsset.php
@@ -238,21 +238,27 @@ class MockAsset extends Asset
         return $this->_focalPoint !== null;
     }
 
+    /**
+     * Mirrors {@see Asset::getFocalPoint()} exactly: null for non-visual kinds,
+     * otherwise the set focal point or Craft's center default (`0.5/0.5`) — a
+     * real image Asset never returns null here, so a mock must not either
+     * (`object-position: {{ asset.getFocalPoint(true) }}` has to behave the
+     * same for both). `getHasFocalPoint()` still reports false when unset,
+     * matching Craft.
+     */
     public function getFocalPoint(bool $asCss = false): array|string|null
     {
-        if ($this->_focalPoint === null) {
+        if (!in_array($this->kind, [self::KIND_IMAGE, self::KIND_VIDEO], true)) {
             return null;
         }
 
+        $focal = $this->_focalPoint ?? ['x' => 0.5, 'y' => 0.5];
+
         if ($asCss) {
-            return sprintf(
-                '%s%% %s%%',
-                $this->_focalPoint['x'] * 100,
-                $this->_focalPoint['y'] * 100,
-            );
+            return sprintf('%s%% %s%%', $focal['x'] * 100, $focal['y'] * 100);
         }
 
-        return $this->_focalPoint;
+        return $focal;
     }
 
     public function setFocalPoint(array|string|null $value): void

--- a/src/models/MockAsset.php
+++ b/src/models/MockAsset.php
@@ -1,0 +1,245 @@
+<?php
+
+namespace viget\partskit\models;
+
+use craft\base\FsInterface;
+use craft\elements\Asset;
+use craft\elements\User;
+use craft\helpers\Image;
+use craft\helpers\ImageTransforms;
+use craft\models\FieldLayout;
+use craft\models\ImageTransform;
+use craft\models\Volume;
+use craft\models\VolumeFolder;
+use yii\base\NotSupportedException;
+use yii\helpers\ArrayHelper;
+
+/**
+ * A placeholder Asset for Parts Kit previews.
+ *
+ * MockAsset extends {@see Asset} but is **not** a Liskov-substitutable Asset: it
+ * has no row in the `assets` table, no Volume, no filesystem, and no field
+ * layout. It implements only the subset of the Asset surface that real-world
+ * Twig component templates actually consume — dimensions, transform-aware
+ * sizing, alt/title, filename/extension/mimeType/kind, and focal point. Every
+ * DB- or volume-touching method throws {@see NotSupportedException}. Callers
+ * that need a full Asset must not receive a MockAsset.
+ *
+ * Construction is normally driven by {@see MockAssetBuilder::one()}, which
+ * passes a config array. Mock-specific keys (`width`, `height`, `label`,
+ * `filename`, `focalPoint`) are extracted into typed properties here; `alt` and
+ * `title` flow through the normal Asset/Element config handling.
+ *
+ * URL emission (`getUrl`/`getImg`/`getSrcset`) lands in U6; this unit covers the
+ * non-URL surface.
+ */
+class MockAsset extends Asset
+{
+    /**
+     * Extension → MIME map for the handful of image formats a mock filename may
+     * carry. Anything else falls back to `image/png`.
+     */
+    private const MIME_TYPES = [
+        'png' => 'image/png',
+        'jpg' => 'image/jpeg',
+        'jpeg' => 'image/jpeg',
+        'gif' => 'image/gif',
+        'webp' => 'image/webp',
+        'avif' => 'image/avif',
+        'svg' => 'image/svg+xml',
+    ];
+
+    private ?int $_width = null;
+
+    private ?int $_height = null;
+
+    private ?string $_label = null;
+
+    private ?string $_filename = null;
+
+    /**
+     * @var array{x: float, y: float}|null
+     */
+    private ?array $_focalPoint = null;
+
+    /**
+     * @param array<string, mixed> $config
+     */
+    public function __construct($config = [])
+    {
+        $this->_width = ArrayHelper::remove($config, 'width');
+        $this->_height = ArrayHelper::remove($config, 'height');
+        $this->_label = ArrayHelper::remove($config, 'label');
+
+        $filename = ArrayHelper::remove($config, 'filename');
+        if ($filename !== null) {
+            $this->_filename = $filename;
+        }
+
+        /** @var array{x: float, y: float}|null $focalPoint */
+        $focalPoint = ArrayHelper::remove($config, 'focalPoint');
+        $this->_focalPoint = $focalPoint;
+
+        parent::__construct($config);
+    }
+
+    public function init(): void
+    {
+        parent::init();
+
+        // A mock has no DB row or volume; pin a sentinel id and force the image
+        // kind so component code branching on `kind`/`id` behaves predictably.
+        $this->id = -1;
+        $this->kind = Asset::KIND_IMAGE;
+        $this->setScenario(self::SCENARIO_CREATE);
+    }
+
+    /**
+     * The mock's label (used as generated-image text and in the signed URL
+     * payload). Not part of the Asset surface — specific to mocks.
+     */
+    public function getLabel(): ?string
+    {
+        return $this->_label;
+    }
+
+    public function getWidth(array|string|ImageTransform $transform = null): ?int
+    {
+        return $this->_resolveDimensions($transform)[0];
+    }
+
+    public function getHeight(mixed $transform = null): ?int
+    {
+        return $this->_resolveDimensions($transform)[1];
+    }
+
+    public function getFilename(bool $withExtension = true): string
+    {
+        $filename = $this->_filename
+            ?? sprintf('mock-%dx%d.png', $this->_width ?? 0, $this->_height ?? 0);
+
+        if (!$withExtension) {
+            return pathinfo($filename, PATHINFO_FILENAME);
+        }
+
+        return $filename;
+    }
+
+    public function setFilename(string $filename): void
+    {
+        $this->_filename = $filename;
+    }
+
+    public function getExtension(): string
+    {
+        return strtolower(pathinfo($this->getFilename(), PATHINFO_EXTENSION) ?: 'png');
+    }
+
+    public function getMimeType(mixed $transform = null): ?string
+    {
+        return self::MIME_TYPES[$this->getExtension()] ?? 'image/png';
+    }
+
+    public function getHasFocalPoint(): bool
+    {
+        return $this->_focalPoint !== null;
+    }
+
+    public function getFocalPoint(bool $asCss = false): array|string|null
+    {
+        if ($this->_focalPoint === null) {
+            return null;
+        }
+
+        if ($asCss) {
+            return sprintf(
+                '%s%% %s%%',
+                $this->_focalPoint['x'] * 100,
+                $this->_focalPoint['y'] * 100,
+            );
+        }
+
+        return $this->_focalPoint;
+    }
+
+    public function setFocalPoint(array|string|null $value): void
+    {
+        $this->_focalPoint = is_array($value) ? $value : null;
+    }
+
+    // --- Unsupported surface -------------------------------------------------
+    // Methods that would touch the database, a Volume, a filesystem, or the
+    // field layout. A mock has none of these, so they fail loudly rather than
+    // returning misleading empty data.
+
+    public function getVolume(): Volume
+    {
+        throw $this->_unsupported(__METHOD__);
+    }
+
+    public function getFolder(): VolumeFolder
+    {
+        throw $this->_unsupported(__METHOD__);
+    }
+
+    public function getFs(): FsInterface
+    {
+        throw $this->_unsupported(__METHOD__);
+    }
+
+    public function getUploader(): ?User
+    {
+        throw $this->_unsupported(__METHOD__);
+    }
+
+    public function getFieldLayout(): ?FieldLayout
+    {
+        throw $this->_unsupported(__METHOD__);
+    }
+
+    public function getFieldValue(string $fieldHandle): mixed
+    {
+        throw $this->_unsupported(__METHOD__);
+    }
+
+    public function getFieldValues(?array $fieldHandles = null): array
+    {
+        throw $this->_unsupported(__METHOD__);
+    }
+
+    /**
+     * Resolves the mock's dimensions for an optional transform. With no
+     * transform (or no base dimensions) the base size is returned; otherwise the
+     * mode-aware target size is computed exactly as Craft would for a real asset.
+     *
+     * @return array{0: int|null, 1: int|null}
+     */
+    private function _resolveDimensions(mixed $transform): array
+    {
+        if ($this->_width === null || $this->_height === null) {
+            return [$this->_width, $this->_height];
+        }
+
+        $normalized = ImageTransforms::normalizeTransform($transform);
+
+        if ($normalized === null) {
+            return [$this->_width, $this->_height];
+        }
+
+        return Image::targetDimensions(
+            $this->_width,
+            $this->_height,
+            $normalized->width,
+            $normalized->height,
+            $normalized->mode,
+            $normalized->upscale,
+        );
+    }
+
+    private function _unsupported(string $method): NotSupportedException
+    {
+        return new NotSupportedException(
+            $method . ' is not supported on MockAsset; see README.',
+        );
+    }
+}

--- a/src/models/MockAsset.php
+++ b/src/models/MockAsset.php
@@ -5,12 +5,17 @@ namespace viget\partskit\models;
 use craft\base\FsInterface;
 use craft\elements\Asset;
 use craft\elements\User;
+use craft\helpers\Assets as AssetsHelper;
+use craft\helpers\Html;
 use craft\helpers\Image;
 use craft\helpers\ImageTransforms;
+use craft\helpers\Template;
 use craft\models\FieldLayout;
 use craft\models\ImageTransform;
 use craft\models\Volume;
 use craft\models\VolumeFolder;
+use Twig\Markup;
+use viget\partskit\Plugin;
 use yii\base\NotSupportedException;
 use yii\helpers\ArrayHelper;
 
@@ -63,6 +68,14 @@ class MockAsset extends Asset
     private ?array $_focalPoint = null;
 
     /**
+     * Memoized signed URLs, keyed by resolved `{width}x{height}`. Rendering the
+     * same image at the same size never re-signs.
+     *
+     * @var array<string, string>
+     */
+    private array $_urlCache = [];
+
+    /**
      * @param array<string, mixed> $config
      */
     public function __construct($config = [])
@@ -101,6 +114,116 @@ class MockAsset extends Asset
     public function getLabel(): ?string
     {
         return $this->_label;
+    }
+
+    /**
+     * Emits a signed URL for the mock at the (optionally transformed) size.
+     * This is render-time only: it performs zero Imagick and zero filesystem
+     * work — the PNG is generated lazily by the controller on first request.
+     */
+    public function getUrl(mixed $transform = null, ?bool $immediately = null): ?string
+    {
+        [$width, $height] = $this->_resolveDimensions($transform);
+
+        if ($width === null || $height === null) {
+            return null;
+        }
+
+        $key = $width . 'x' . $height;
+
+        return $this->_urlCache[$key] ??= Plugin::getInstance()
+            ->getAssets()
+            ->signedUrlForImage($width, $height, $this->_label);
+    }
+
+    public function getImg(mixed $transform = null, ?array $sizes = null): ?Markup
+    {
+        if ($this->kind !== self::KIND_IMAGE) {
+            return null;
+        }
+
+        $url = $this->getUrl($transform);
+
+        if ($url === null) {
+            return null;
+        }
+
+        $img = Html::tag('img', '', [
+            'src' => $url,
+            'width' => $this->getWidth($transform),
+            'height' => $this->getHeight($transform),
+            'srcset' => $sizes ? $this->getSrcset($sizes, $transform) : false,
+            'alt' => $this->alt,
+        ]);
+
+        return Template::raw($img);
+    }
+
+    public function getSrcset(array $sizes, mixed $transform = null): string|false
+    {
+        $urls = array_filter($this->getUrlsBySize($sizes, $transform));
+
+        if (empty($urls)) {
+            return false;
+        }
+
+        $srcset = [];
+
+        foreach ($urls as $size => $url) {
+            $srcset[] = $size === '1x' ? $url : "$url $size";
+        }
+
+        return implode(', ', $srcset);
+    }
+
+    /**
+     * @param string[] $sizes
+     * @return array<string, string|null>
+     */
+    public function getUrlsBySize(array $sizes, mixed $transform = null): array
+    {
+        if ($this->kind !== self::KIND_IMAGE) {
+            return [];
+        }
+
+        $normalized = ImageTransforms::normalizeTransform($transform);
+
+        [$currentWidth, $currentHeight] = $this->_resolveDimensions($normalized);
+
+        if (!$currentWidth || !$currentHeight) {
+            return [];
+        }
+
+        $urls = [];
+
+        foreach ($sizes as $size) {
+            if ($size === '1x') {
+                $urls[$size] = $this->getUrl($normalized);
+                continue;
+            }
+
+            [$value, $unit] = AssetsHelper::parseSrcsetSize($size);
+
+            $sizeTransform = $normalized ? $normalized->toArray() : [];
+            unset($sizeTransform['name'], $sizeTransform['handle']);
+
+            if ($unit === 'w') {
+                $sizeTransform['width'] = (int)$value;
+            } else {
+                $sizeTransform['width'] = (int)ceil($currentWidth * $value);
+            }
+
+            // Only carry a height if the base transform set one.
+            if ($normalized && $normalized->height) {
+                $sizeTransform['height'] = $unit === 'w'
+                    ? (int)ceil($currentHeight * $sizeTransform['width'] / $currentWidth)
+                    : (int)ceil($currentHeight * $value);
+            }
+
+            $urls["$value$unit"] = $this->getUrl($sizeTransform);
+        }
+
+        return $urls;
     }
 
     public function getWidth(array|string|ImageTransform $transform = null): ?int

--- a/src/models/MockAsset.php
+++ b/src/models/MockAsset.php
@@ -35,9 +35,6 @@ use yii\helpers\ArrayHelper;
  * passes a config array. Mock-specific keys (`width`, `height`, `label`,
  * `filename`, `focalPoint`) are extracted into typed properties here; `alt` and
  * `title` flow through the normal Asset/Element config handling.
- *
- * URL emission (`getUrl`/`getImg`/`getSrcset`) lands in U6; this unit covers the
- * non-URL surface.
  */
 class MockAsset extends Asset
 {

--- a/src/models/MockAsset.php
+++ b/src/models/MockAsset.php
@@ -142,11 +142,13 @@ class MockAsset extends Asset
         return Template::raw($img);
     }
 
-    // getSrcset() is inherited from Asset: its body is just
-    // `array_filter($this->getUrlsBySize(...))` formatted into a srcset string,
-    // and getUrlsBySize() is overridden below to emit signed mock URLs.
-
     /**
+     * Ported from {@see Asset::getUrlsBySize()} — same descriptor parsing,
+     * `ceil()` rounding, and only-carry-height-if-the-base-transform-set-one
+     * rule — but emitting signed mock URLs instead of transform URLs.
+     * `getSrcset()` needs no override: Craft's inherited implementation just
+     * formats whatever this method returns into a srcset string.
+     *
      * @param string[] $sizes
      * @return array<string, string|null>
      */
@@ -230,7 +232,10 @@ class MockAsset extends Asset
 
     public function getMimeType(mixed $transform = null): ?string
     {
-        return FileHelper::getMimeTypeByExtension($this->getFilename()) ?? 'image/png';
+        // No fallback: an unrecognized extension honestly reports null rather
+        // than claiming image/png. (The default mock-{w}x{h}.png filename
+        // always resolves.)
+        return FileHelper::getMimeTypeByExtension($this->getFilename());
     }
 
     public function getHasFocalPoint(): bool

--- a/src/models/MockAssetBuilder.php
+++ b/src/models/MockAssetBuilder.php
@@ -2,14 +2,150 @@
 
 namespace viget\partskit\models;
 
+use InvalidArgumentException;
+
 /**
  * Accumulates mock-asset configuration and constructs a {@see MockAsset} in
  * one().
  *
- * Scaffolded in U1 as the return type of
- * {@see \viget\partskit\services\Assets::make()}. The fluent setters,
- * configure(), defaults, and the 200-char label cap are added in U3.
+ * Two interchangeable styles are supported (the user chose both in the
+ * brainstorm):
+ *
+ * ```php
+ * // Fluent chain
+ * $asset = (new MockAssetBuilder())->width(400)->height(300)->label('Thumb')->one();
+ *
+ * // Array config
+ * $asset = (new MockAssetBuilder())->configure(['width' => 400, 'height' => 300])->one();
+ * ```
+ *
+ * The builder never touches a {@see MockAsset} until one(): it only holds a
+ * config array, applies defaults, and constructs the element via
+ * `new MockAsset($config)` (the standard Yii `new X($config)` idiom).
  */
 class MockAssetBuilder
 {
+    /**
+     * Config keys accepted by {@see configure()}. Each maps to a fluent setter
+     * of the same name, so configure() and the chain share one validation path.
+     *
+     * @var list<string>
+     */
+    private const ALLOWED_KEYS = [
+        'width',
+        'height',
+        'label',
+        'alt',
+        'title',
+        'filename',
+        'focalPoint',
+    ];
+
+    private const MAX_LABEL_LENGTH = 200;
+
+    private const DEFAULT_WIDTH = 800;
+
+    private const DEFAULT_HEIGHT = 600;
+
+    /**
+     * @var array<string, mixed>
+     */
+    private array $_config = [];
+
+    /**
+     * Merges an array of config, validating keys and routing each value through
+     * its fluent setter (so the label cap and trimming apply uniformly).
+     *
+     * @param array<string, mixed> $config
+     * @throws InvalidArgumentException if a key is not recognized
+     */
+    public function configure(array $config): self
+    {
+        foreach ($config as $key => $value) {
+            if (!in_array($key, self::ALLOWED_KEYS, true)) {
+                throw new InvalidArgumentException(
+                    sprintf('Unknown mock asset config key "%s".', $key),
+                );
+            }
+
+            $this->{$key}($value);
+        }
+
+        return $this;
+    }
+
+    public function width(int $width): self
+    {
+        $this->_config['width'] = $width;
+
+        return $this;
+    }
+
+    public function height(int $height): self
+    {
+        $this->_config['height'] = $height;
+
+        return $this;
+    }
+
+    public function label(string $label): self
+    {
+        $label = trim($label);
+
+        if (mb_strlen($label) > self::MAX_LABEL_LENGTH) {
+            throw new InvalidArgumentException(
+                sprintf('Mock asset label must be %d characters or fewer.', self::MAX_LABEL_LENGTH),
+            );
+        }
+
+        $this->_config['label'] = $label;
+
+        return $this;
+    }
+
+    public function alt(string $alt): self
+    {
+        $this->_config['alt'] = $alt;
+
+        return $this;
+    }
+
+    public function title(string $title): self
+    {
+        $this->_config['title'] = $title;
+
+        return $this;
+    }
+
+    public function filename(string $filename): self
+    {
+        $this->_config['filename'] = $filename;
+
+        return $this;
+    }
+
+    /**
+     * @param array{x: float, y: float} $focalPoint
+     */
+    public function focalPoint(array $focalPoint): self
+    {
+        $this->_config['focalPoint'] = $focalPoint;
+
+        return $this;
+    }
+
+    /**
+     * Applies defaults and constructs a fresh {@see MockAsset}. Each call
+     * returns a distinct instance — the builder holds no mock state between
+     * calls.
+     */
+    public function one(): MockAsset
+    {
+        $config = array_merge(
+            ['width' => self::DEFAULT_WIDTH, 'height' => self::DEFAULT_HEIGHT],
+            $this->_config,
+        );
+
+        return new MockAsset($config);
+    }
 }

--- a/src/models/MockAssetBuilder.php
+++ b/src/models/MockAssetBuilder.php
@@ -3,6 +3,7 @@
 namespace viget\partskit\models;
 
 use InvalidArgumentException;
+use viget\partskit\helpers\MockImageGenerator;
 
 /**
  * Accumulates mock-asset configuration and constructs a {@see MockAsset} in
@@ -76,16 +77,37 @@ class MockAssetBuilder
 
     public function width(int $width): self
     {
-        $this->_config['width'] = $width;
+        $this->_config['width'] = $this->assertDimension($width, 'width');
 
         return $this;
     }
 
     public function height(int $height): self
     {
-        $this->_config['height'] = $height;
+        $this->_config['height'] = $this->assertDimension($height, 'height');
 
         return $this;
+    }
+
+    /**
+     * Dimensions must be a positive integer no larger than
+     * {@see MockImageGenerator::MAX_DIMENSION}, so a typo (or a hostile template)
+     * can't request an enormous canvas.
+     *
+     * @throws InvalidArgumentException when out of range
+     */
+    private function assertDimension(int $value, string $name): int
+    {
+        if ($value < 1 || $value > MockImageGenerator::MAX_DIMENSION) {
+            throw new InvalidArgumentException(sprintf(
+                'Mock asset %s must be between 1 and %d, got %d.',
+                $name,
+                MockImageGenerator::MAX_DIMENSION,
+                $value,
+            ));
+        }
+
+        return $value;
     }
 
     public function label(string $label): self

--- a/src/services/Assets.php
+++ b/src/services/Assets.php
@@ -21,8 +21,9 @@ use yii\helpers\StringHelper;
  * tamper-proof: {@see \viget\partskit\controllers\MockController} validates it
  * before serving and rejects any mutation with a 404. Because the validated
  * config travels in the URL, the controller can generate the PNG lazily on the
- * first request — no sidecar files, no DB. The on-disk cache filename is
- * `sha1($payload)`, computed by the controller (not here).
+ * first request — no sidecar files, no DB. This service also owns the on-disk
+ * cache location: {@see cachePathForPayload()} derives `sha1($payload).png`
+ * under {@see CACHE_DIRECTORY}.
  */
 class Assets extends Component
 {

--- a/src/services/Assets.php
+++ b/src/services/Assets.php
@@ -27,6 +27,13 @@ use yii\helpers\StringHelper;
 class Assets extends Component
 {
     /**
+     * Alias of the directory holding the lazily-generated mock PNGs. Single
+     * source of truth: the controller (cache path), the generator (via that
+     * path), and the clear-caches registration all derive from here.
+     */
+    public const CACHE_DIRECTORY = '@storage/runtime/parts-kit-mocks';
+
+    /**
      * Returns a builder for a mock asset, applying any provided config. Runs the
      * Imagick boot guard so misconfigured environments fail with a clear message
      * at the point of use rather than deep inside generation.
@@ -64,6 +71,24 @@ class Assets extends Component
         $directory = Plugin::getInstance()->getSettings()->directory;
 
         return UrlHelper::siteUrl($directory . '/mock/' . $token . '.png');
+    }
+
+    /**
+     * The resolved (absolute) mock-image cache directory.
+     */
+    public function cacheDirectory(): string
+    {
+        return Craft::getAlias(self::CACHE_DIRECTORY);
+    }
+
+    /**
+     * The on-disk cache path for a validated signed payload. The filename is the
+     * SHA-1 of the payload — never raw input — so there is no path-traversal
+     * surface and identical configs share one file.
+     */
+    public function cachePathForPayload(string $payload): string
+    {
+        return $this->cacheDirectory() . '/' . sha1($payload) . '.png';
     }
 
     private function _ensureImagickAvailable(): void

--- a/src/services/Assets.php
+++ b/src/services/Assets.php
@@ -2,27 +2,77 @@
 
 namespace viget\partskit\services;
 
+use Craft;
+use craft\helpers\Json;
+use craft\helpers\UrlHelper;
+use RuntimeException;
 use viget\partskit\models\MockAssetBuilder;
+use viget\partskit\Plugin;
 use yii\base\Component;
+use yii\helpers\StringHelper;
 
 /**
  * Assets service — the entry point for building mock assets from Twig
- * (`partsKit.assets.make(...)`).
+ * (`partsKit.assets.make(...)`) and the single source of truth for mock-image
+ * URL routing and signing.
  *
- * U1 establishes the service and the make() seam. The Imagick boot check,
- * config application, and signedUrlForImage() (routing + HMAC signing) land in
- * U5.
+ * A mock image URL carries an HMAC-signed, base64url-encoded JSON payload
+ * (`{w, h, label}`) as its path token. The signature makes the URL
+ * tamper-proof: {@see \viget\partskit\controllers\MockController} validates it
+ * before serving and rejects any mutation with a 404. Because the validated
+ * config travels in the URL, the controller can generate the PNG lazily on the
+ * first request — no sidecar files, no DB. The on-disk cache filename is
+ * `sha1($payload)`, computed by the controller (not here).
  */
 class Assets extends Component
 {
     /**
-     * Returns a builder for a mock asset. Config is applied in U5; for now this
-     * returns an empty builder regardless of the passed config.
+     * Returns a builder for a mock asset, applying any provided config. Runs the
+     * Imagick boot guard so misconfigured environments fail with a clear message
+     * at the point of use rather than deep inside generation.
      *
      * @param array<string, mixed> $config
+     * @throws RuntimeException if the Imagick extension is unavailable
      */
     public function make(array $config = []): MockAssetBuilder
     {
-        return new MockAssetBuilder();
+        $this->_ensureImagickAvailable();
+
+        $builder = new MockAssetBuilder();
+
+        if ($config !== []) {
+            $builder->configure($config);
+        }
+
+        return $builder;
+    }
+
+    /**
+     * Builds the tamper-proof, signed site URL that serves a mock PNG of the
+     * given dimensions and label. Rendering only ever emits this string — no
+     * image is generated until the URL is requested.
+     */
+    public function signedUrlForImage(int $width, int $height, ?string $label): string
+    {
+        $payload = Json::encode(['w' => $width, 'h' => $height, 'label' => $label]);
+        $signed = Craft::$app->getSecurity()->hashData($payload);
+
+        // Strip base64 padding so the token matches the `[A-Za-z0-9_-]+` route
+        // pattern; base64 decoding tolerates the missing padding on the way back.
+        $token = rtrim(StringHelper::base64UrlEncode($signed), '=');
+
+        $directory = Plugin::getInstance()->getSettings()->directory;
+
+        return UrlHelper::siteUrl($directory . '/mock/' . $token . '.png');
+    }
+
+    private function _ensureImagickAvailable(): void
+    {
+        if (!extension_loaded('imagick')) {
+            throw new RuntimeException(
+                'Parts Kit mock assets require the PHP Imagick extension (ext-imagick). '
+                . 'Install it to render mock images. See README.',
+            );
+        }
     }
 }

--- a/tests/_craft/config/parts-kit.php
+++ b/tests/_craft/config/parts-kit.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * Test-harness override for the Parts Kit plugin settings.
+ *
+ * The Craft test connector rebuilds the application on every functional request,
+ * so a test cannot toggle the visibility gate by mutating the in-memory settings
+ * model — the next request gets a fresh plugin with default settings. This file
+ * is re-evaluated on each app build, so functional tests drive the gate through
+ * the `PARTS_KIT_REQUIRE_VIEW_PERMISSION` env var instead.
+ *
+ * Default mirrors the production default (gate on). Set the env var to `0` to
+ * open the route to anonymous requests.
+ */
+return [
+    'requireViewPermission' => getenv('PARTS_KIT_REQUIRE_VIEW_PERMISSION') !== '0',
+];

--- a/tests/functional/MockControllerCest.php
+++ b/tests/functional/MockControllerCest.php
@@ -6,6 +6,7 @@ use Craft;
 use craft\elements\User;
 use craft\helpers\FileHelper;
 use FunctionalTester;
+use viget\partskit\helpers\MockImageGenerator;
 use viget\partskit\services\Assets;
 
 /**
@@ -24,7 +25,12 @@ use viget\partskit\services\Assets;
  */
 class MockControllerCest
 {
-    private const MOCKS_DIR = '@storage/runtime/parts-kit-mocks';
+    public function _before(FunctionalTester $I): void
+    {
+        // Each test starts from an empty cache so on-disk assertions don't
+        // depend on execution order.
+        $this->clearMocksDir();
+    }
 
     public function _after(FunctionalTester $I): void
     {
@@ -65,7 +71,7 @@ class MockControllerCest
 
     private function mocksDir(): string
     {
-        return Craft::getAlias(self::MOCKS_DIR);
+        return Craft::getAlias(Assets::CACHE_DIRECTORY);
     }
 
     private function clearMocksDir(): void
@@ -90,7 +96,6 @@ class MockControllerCest
         // Covers AC2 — 200 with image/png + immutable cache, and the served file
         // is exactly 800x600.
         $this->requireGate(false);
-        $this->clearMocksDir();
 
         $I->amOnPage($this->mockPath(800, 600, null));
         $I->seeResponseCodeIs(200);
@@ -113,7 +118,6 @@ class MockControllerCest
     {
         // Covers AC12 — first request generates the file, second hits the cache.
         $this->requireGate(false);
-        $this->clearMocksDir();
 
         $path = $this->mockPath(640, 480, 'Cold');
 
@@ -131,6 +135,33 @@ class MockControllerCest
         $this->requireGate(false);
 
         $I->amOnPage($this->tamper($this->mockPath(800, 600, null)));
+        $I->seeResponseCodeIs(404);
+    }
+
+    public function outOfRangeDimensionsReturn404(FunctionalTester $I): void
+    {
+        // A validly-signed token whose dimensions exceed the canvas cap is
+        // rejected before it can allocate a huge Imagick image.
+        $this->requireGate(false);
+
+        $oversize = MockImageGenerator::MAX_DIMENSION + 1;
+        $I->amOnPage($this->mockPath($oversize, $oversize, null));
+        $I->seeResponseCodeIs(404);
+    }
+
+    public function fileCountCapReturns404(FunctionalTester $I): void
+    {
+        // When the cache is at the file-count cap, generation aborts and the
+        // controller serves a 404 rather than an error.
+        $this->requireGate(false);
+
+        $dir = $this->mocksDir();
+        FileHelper::createDirectory($dir);
+        for ($i = 0; $i < MockImageGenerator::MAX_FILES; $i++) {
+            touch($dir . '/cap-stub-' . $i . '.png');
+        }
+
+        $I->amOnPage($this->mockPath(800, 600, 'Capped'));
         $I->seeResponseCodeIs(404);
     }
 

--- a/tests/functional/MockControllerCest.php
+++ b/tests/functional/MockControllerCest.php
@@ -1,0 +1,193 @@
+<?php
+
+namespace viget\partskit\tests\functional;
+
+use Craft;
+use craft\elements\User;
+use craft\helpers\FileHelper;
+use FunctionalTester;
+use viget\partskit\services\Assets;
+
+/**
+ * HTTP-level behavior of MockController: signed-token routing, the Parts Kit
+ * visibility gate, lazy cold-cache generation, and tamper rejection.
+ *
+ * Tokens are minted in-process via Assets::signedUrlForImage() (fixed
+ * SECURITY_KEY makes them deterministic); the path segment is then requested
+ * through the functional connector.
+ *
+ * The connector rebuilds the app per request, so the visibility gate is driven
+ * through the PARTS_KIT_REQUIRE_VIEW_PERMISSION env var, which the harness's
+ * config/parts-kit.php re-reads on each build. The served PNG bytes are asserted
+ * against the on-disk cache file rather than the response body, since the
+ * functional connector does not expose response headers/binary bodies directly.
+ */
+class MockControllerCest
+{
+    private const MOCKS_DIR = '@storage/runtime/parts-kit-mocks';
+
+    public function _after(FunctionalTester $I): void
+    {
+        putenv('PARTS_KIT_REQUIRE_VIEW_PERMISSION');
+    }
+
+    private function requireGate(bool $required): void
+    {
+        putenv('PARTS_KIT_REQUIRE_VIEW_PERMISSION=' . ($required ? '1' : '0'));
+    }
+
+    private function mockPath(int $width, int $height, ?string $label): string
+    {
+        $url = (new Assets())->signedUrlForImage($width, $height, $label);
+
+        return parse_url($url, PHP_URL_PATH);
+    }
+
+    private function tamper(string $path): string
+    {
+        return preg_replace_callback(
+            '#/mock/(.)#',
+            fn(array $m) => '/mock/' . ($m[1] === 'A' ? 'B' : 'A'),
+            $path,
+        );
+    }
+
+    private function loginAsAdmin(FunctionalTester $I): void
+    {
+        $user = new User();
+        $user->admin = true;
+        $user->username = 'mock-tester-' . bin2hex(random_bytes(4));
+        $user->email = $user->username . '@example.test';
+        Craft::$app->getElements()->saveElement($user, false);
+
+        $I->amLoggedInAs($user);
+    }
+
+    private function mocksDir(): string
+    {
+        return Craft::getAlias(self::MOCKS_DIR);
+    }
+
+    private function clearMocksDir(): void
+    {
+        $dir = $this->mocksDir();
+
+        if (is_dir($dir)) {
+            FileHelper::clearDirectory($dir);
+        }
+    }
+
+    /**
+     * @return string[]
+     */
+    private function cachedFiles(): array
+    {
+        return glob($this->mocksDir() . '/*.png') ?: [];
+    }
+
+    public function validTokenReturns200PngOfExactDimensions(FunctionalTester $I): void
+    {
+        // Covers AC2 — 200 with image/png + immutable cache, and the served file
+        // is exactly 800x600.
+        $this->requireGate(false);
+        $this->clearMocksDir();
+
+        $I->amOnPage($this->mockPath(800, 600, null));
+        $I->seeResponseCodeIs(200);
+
+        $headers = Craft::$app->getResponse()->getHeaders();
+        $I->assertSame('image/png', $headers->get('Content-Type'));
+        $I->assertSame('public, max-age=31536000, immutable', $headers->get('Cache-Control'));
+
+        $files = $this->cachedFiles();
+        $I->assertCount(1, $files);
+
+        $info = getimagesize($files[0]);
+        $I->assertNotFalse($info);
+        $I->assertSame(800, $info[0]);
+        $I->assertSame(600, $info[1]);
+        $I->assertSame('image/png', $info['mime']);
+    }
+
+    public function coldCacheGeneratesThenServes(FunctionalTester $I): void
+    {
+        // Covers AC12 — first request generates the file, second hits the cache.
+        $this->requireGate(false);
+        $this->clearMocksDir();
+
+        $path = $this->mockPath(640, 480, 'Cold');
+
+        $I->amOnPage($path);
+        $I->seeResponseCodeIs(200);
+        $I->assertNotEmpty($this->cachedFiles(), 'First request generated the PNG on disk');
+
+        $I->amOnPage($path);
+        $I->seeResponseCodeIs(200);
+    }
+
+    public function tamperedTokenReturns404(FunctionalTester $I): void
+    {
+        // Covers AC13 — a one-byte mutation fails signature validation.
+        $this->requireGate(false);
+
+        $I->amOnPage($this->tamper($this->mockPath(800, 600, null)));
+        $I->seeResponseCodeIs(404);
+    }
+
+    public function anonymousDeniedWhenPermissionRequired(FunctionalTester $I): void
+    {
+        // Covers NFR3 — gated + unauthorized → 403.
+        $this->requireGate(true);
+
+        $I->amOnPage($this->mockPath(800, 600, null));
+        $I->seeResponseCodeIs(403);
+    }
+
+    public function adminAllowedWhenPermissionRequired(FunctionalTester $I): void
+    {
+        $this->requireGate(true);
+        $this->loginAsAdmin($I);
+
+        $I->amOnPage($this->mockPath(800, 600, null));
+        $I->seeResponseCodeIs(200);
+    }
+
+    public function publicWhenPermissionNotRequired(FunctionalTester $I): void
+    {
+        $this->requireGate(false);
+
+        $I->amOnPage($this->mockPath(800, 600, null));
+        $I->seeResponseCodeIs(200);
+    }
+
+    public function gateRunsBeforeValidation(FunctionalTester $I): void
+    {
+        // Covers NFR8 — anonymous + tampered token → 403 (not 404): the gate
+        // runs before signature validation, so there is no token oracle.
+        $this->requireGate(true);
+
+        $I->amOnPage($this->tamper($this->mockPath(800, 600, null)));
+        $I->seeResponseCodeIs(403);
+    }
+
+    public function differentLabelsServeSeparateFiles(FunctionalTester $I): void
+    {
+        // Covers AC7 end-to-end — two URLs differing only by label are distinct
+        // and both serve. The on-disk filename is sha1(payload), so distinct
+        // tokens map to distinct cache files (the hash difference itself is
+        // pinned by AssetsTest::testDifferentLabelProducesDifferentHash). The
+        // harness rebuilds @storage per request, so this asserts the routing
+        // identity rather than accumulating both files in one directory.
+        $this->requireGate(false);
+
+        $hero = $this->mockPath(800, 600, 'Hero');
+        $thumbnail = $this->mockPath(800, 600, 'Thumbnail');
+        $I->assertNotSame($hero, $thumbnail, 'Different labels produce different URLs');
+
+        $I->amOnPage($hero);
+        $I->seeResponseCodeIs(200);
+
+        $I->amOnPage($thumbnail);
+        $I->seeResponseCodeIs(200);
+    }
+}

--- a/tests/unit/PluginWiringTest.php
+++ b/tests/unit/PluginWiringTest.php
@@ -51,7 +51,7 @@ class PluginWiringTest extends Unit
 
     private function mocksDir(): string
     {
-        return Craft::getAlias('@storage/runtime/parts-kit-mocks');
+        return Craft::getAlias(Assets::CACHE_DIRECTORY);
     }
 
     /**

--- a/tests/unit/PluginWiringTest.php
+++ b/tests/unit/PluginWiringTest.php
@@ -3,6 +3,9 @@
 namespace viget\partskit\tests\unit;
 
 use Codeception\Test\Unit;
+use Craft;
+use craft\helpers\FileHelper;
+use craft\utilities\ClearCaches;
 use UnitTester;
 use viget\partskit\Plugin;
 use viget\partskit\services\Assets;
@@ -44,5 +47,51 @@ class PluginWiringTest extends Unit
         // `partsKit.assets` dereferences to the Yii magic property below. This is
         // the seam the Twig usage `partsKit.assets.make(...)` depends on.
         $this->assertInstanceOf(Assets::class, $this->plugin()->assets);
+    }
+
+    private function mocksDir(): string
+    {
+        return Craft::getAlias('@storage/runtime/parts-kit-mocks');
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function mocksCacheOption(): ?array
+    {
+        foreach (ClearCaches::cacheOptions() as $option) {
+            if (($option['key'] ?? null) === 'parts-kit-mocks') {
+                return $option;
+            }
+        }
+
+        return null;
+    }
+
+    public function testCacheOptionRegistered(): void
+    {
+        $option = $this->mocksCacheOption();
+
+        $this->assertNotNull($option, 'A parts-kit-mocks clear-caches option should be registered');
+        $this->assertSame($this->mocksDir(), $option['action']);
+    }
+
+    public function testClearCachesEmptiesMocksDir(): void
+    {
+        // Covers AC9 — invoking the registered action (a directory path, cleared
+        // by FileHelper::clearDirectory exactly as `clear-caches/all` does)
+        // empties the mock image cache.
+        $dir = $this->mocksDir();
+        FileHelper::createDirectory($dir);
+        file_put_contents($dir . '/seed.png', 'not-a-real-png');
+        $this->assertNotEmpty(glob($dir . '/*') ?: []);
+
+        $option = $this->mocksCacheOption();
+        $this->assertNotNull($option);
+        $this->assertIsString($option['action']);
+
+        FileHelper::clearDirectory($option['action']);
+
+        $this->assertSame([], glob($dir . '/*') ?: []);
     }
 }

--- a/tests/unit/helpers/MockImageGeneratorTest.php
+++ b/tests/unit/helpers/MockImageGeneratorTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace viget\partskit\tests\unit\helpers;
+
+use Codeception\Test\Unit;
+use craft\helpers\FileHelper;
+use UnitTester;
+use viget\partskit\helpers\MockImageGenerator;
+
+/**
+ * U7 — MockImageGenerator. Real PNG output is asserted with getimagesize() and
+ * the PNG signature bytes (imagick is loaded in CI). Each test writes to its own
+ * temp directory, cleaned in _after.
+ */
+class MockImageGeneratorTest extends Unit
+{
+    protected UnitTester $tester;
+
+    private string $dir;
+
+    protected function _before(): void
+    {
+        $this->dir = codecept_output_dir() . 'mock-gen-' . bin2hex(random_bytes(6));
+        FileHelper::createDirectory($this->dir);
+    }
+
+    protected function _after(): void
+    {
+        if (is_dir($this->dir)) {
+            FileHelper::removeDirectory($this->dir);
+        }
+    }
+
+    public function testGeneratesPngOfExactDimensions(): void
+    {
+        // Covers AC2 — exact pixel dimensions and PNG mime.
+        $path = $this->dir . '/exact.png';
+        MockImageGenerator::generate($path, 800, 600, null);
+
+        $this->assertFileExists($path);
+
+        $info = getimagesize($path);
+        $this->assertNotFalse($info);
+        $this->assertSame(800, $info[0]);
+        $this->assertSame(600, $info[1]);
+        $this->assertSame('image/png', $info['mime']);
+    }
+
+    public function testGeneratesPngWithCustomLabel(): void
+    {
+        $path = $this->dir . '/labeled.png';
+        MockImageGenerator::generate($path, 400, 300, 'Custom Label');
+
+        $info = getimagesize($path);
+        $this->assertNotFalse($info);
+        $this->assertSame(400, $info[0]);
+        $this->assertSame(300, $info[1]);
+    }
+
+    public function testDefaultLabelIsDimensions(): void
+    {
+        // Smoke: a null label produces a valid PNG (the label defaults to WxH).
+        $path = $this->dir . '/default-label.png';
+        MockImageGenerator::generate($path, 320, 240, null);
+
+        $this->assertFileExists($path);
+        $this->assertNotFalse(getimagesize($path));
+    }
+
+    public function testOutputIsValidPngSignature(): void
+    {
+        $path = $this->dir . '/signature.png';
+        MockImageGenerator::generate($path, 100, 100, null);
+
+        $bytes = file_get_contents($path, false, null, 0, 8);
+        $this->assertSame("\x89PNG\r\n\x1a\x0a", $bytes);
+    }
+
+    public function testAtomicWriteLeavesNoTempFile(): void
+    {
+        // Covers NFR1 — the final file exists and no temp sibling remains.
+        $path = $this->dir . '/atomic.png';
+        MockImageGenerator::generate($path, 200, 200, null);
+
+        $this->assertFileExists($path);
+        $this->assertSame([], glob($this->dir . '/*.tmp.*') ?: []);
+    }
+
+    public function testFileCountCapAbortsGeneration(): void
+    {
+        // Covers NFR6 — at the cap, generation is skipped and no file is written.
+        for ($i = 0; $i < MockImageGenerator::MAX_FILES; $i++) {
+            touch($this->dir . '/stub-' . $i . '.png');
+        }
+
+        $path = $this->dir . '/over-cap.png';
+        MockImageGenerator::generate($path, 800, 600, null);
+
+        $this->assertFileDoesNotExist($path);
+    }
+
+    public function testSmallDimensionsFloorFontAt8px(): void
+    {
+        // The font floor prevents a zero/negative point size on tiny canvases.
+        $path = $this->dir . '/tiny.png';
+        MockImageGenerator::generate($path, 10, 10, '10x10');
+
+        $info = getimagesize($path);
+        $this->assertNotFalse($info);
+        $this->assertSame(10, $info[0]);
+        $this->assertSame(10, $info[1]);
+    }
+
+    public function testBundledFontResolves(): void
+    {
+        // Guard-shape assertion for the font chain: the bundled DejaVu Sans must
+        // ship so generation never falls through to the RuntimeException on a
+        // clean install. (The throw path itself is unreachable while the bundled
+        // font is present — see resolveFont().)
+        $bundled = dirname(__DIR__, 3) . '/src/resources/fonts/DejaVuSans.ttf';
+        $this->assertFileExists($bundled);
+    }
+}

--- a/tests/unit/models/MockAssetBuilderTest.php
+++ b/tests/unit/models/MockAssetBuilderTest.php
@@ -5,6 +5,7 @@ namespace viget\partskit\tests\unit\models;
 use Codeception\Test\Unit;
 use InvalidArgumentException;
 use UnitTester;
+use viget\partskit\helpers\MockImageGenerator;
 use viget\partskit\models\MockAsset;
 use viget\partskit\models\MockAssetBuilder;
 
@@ -82,6 +83,38 @@ class MockAssetBuilderTest extends Unit
         $asset = (new MockAssetBuilder())->label($label)->one();
 
         $this->assertSame($label, $asset->getLabel());
+    }
+
+    public function testZeroDimensionThrows(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        (new MockAssetBuilder())->width(0);
+    }
+
+    public function testNegativeDimensionThrows(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        (new MockAssetBuilder())->height(-10);
+    }
+
+    public function testDimensionOverMaxThrows(): void
+    {
+        // Guards against an enormous Imagick canvas (resource exhaustion).
+        $this->expectException(InvalidArgumentException::class);
+
+        (new MockAssetBuilder())->width(MockImageGenerator::MAX_DIMENSION + 1);
+    }
+
+    public function testMaxDimensionIsAccepted(): void
+    {
+        $asset = (new MockAssetBuilder())
+            ->width(MockImageGenerator::MAX_DIMENSION)
+            ->height(MockImageGenerator::MAX_DIMENSION)
+            ->one();
+
+        $this->assertSame(MockImageGenerator::MAX_DIMENSION, $asset->getWidth());
     }
 
     public function testOneReturnsFreshInstances(): void

--- a/tests/unit/models/MockAssetBuilderTest.php
+++ b/tests/unit/models/MockAssetBuilderTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace viget\partskit\tests\unit\models;
+
+use Codeception\Test\Unit;
+use InvalidArgumentException;
+use UnitTester;
+use viget\partskit\models\MockAsset;
+use viget\partskit\models\MockAssetBuilder;
+
+/**
+ * U3 — MockAssetBuilder. Accumulates config via a fluent chain or configure()
+ * array and constructs a MockAsset only in one(). Defaults are 800x600; labels
+ * are trimmed and capped at 200 chars; unknown keys throw.
+ */
+class MockAssetBuilderTest extends Unit
+{
+    protected UnitTester $tester;
+
+    public function testFluentSettersAccumulateConfig(): void
+    {
+        $asset = (new MockAssetBuilder())
+            ->width(1024)
+            ->height(768)
+            ->label('Hero')
+            ->alt('Hero photo')
+            ->one();
+
+        $this->assertInstanceOf(MockAsset::class, $asset);
+        $this->assertSame(1024, $asset->getWidth());
+        $this->assertSame(768, $asset->getHeight());
+        $this->assertSame('Hero', $asset->getLabel());
+        $this->assertSame('Hero photo', $asset->alt);
+    }
+
+    public function testConfigureMergesArray(): void
+    {
+        $asset = (new MockAssetBuilder())
+            ->configure(['width' => 400, 'height' => 300])
+            ->one();
+
+        $this->assertSame(400, $asset->getWidth());
+        $this->assertSame(300, $asset->getHeight());
+    }
+
+    public function testUnknownConfigKeyThrows(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/bogus/');
+
+        (new MockAssetBuilder())->configure(['bogus' => 1]);
+    }
+
+    public function testDefaultsAppliedWhenUnset(): void
+    {
+        // Covers AC3 — make.one with no setters yields the 800x600 default.
+        $asset = (new MockAssetBuilder())->one();
+
+        $this->assertSame(800, $asset->getWidth());
+        $this->assertSame(600, $asset->getHeight());
+    }
+
+    public function testLabelOver200CharsThrows(): void
+    {
+        // Covers NFR7.
+        $this->expectException(InvalidArgumentException::class);
+
+        (new MockAssetBuilder())->label(str_repeat('a', 201));
+    }
+
+    public function testLabelIsTrimmed(): void
+    {
+        $asset = (new MockAssetBuilder())->label('  Hero  ')->one();
+
+        $this->assertSame('Hero', $asset->getLabel());
+    }
+
+    public function testLabelAt200CharsIsAccepted(): void
+    {
+        // Boundary: exactly 200 chars is allowed (cap is "more than 200").
+        $label = str_repeat('a', 200);
+        $asset = (new MockAssetBuilder())->label($label)->one();
+
+        $this->assertSame($label, $asset->getLabel());
+    }
+
+    public function testOneReturnsFreshInstances(): void
+    {
+        $builder = new MockAssetBuilder();
+        $first = $builder->one();
+        $second = $builder->one();
+
+        $this->assertNotSame($first, $second);
+    }
+}

--- a/tests/unit/models/MockAssetTest.php
+++ b/tests/unit/models/MockAssetTest.php
@@ -91,6 +91,16 @@ class MockAssetTest extends Unit
         $this->assertSame('image/jpeg', $asset->getMimeType());
     }
 
+    public function testUnknownExtensionMimeTypeIsNull(): void
+    {
+        // An unrecognized extension reports null rather than a misleading
+        // image/png fallback.
+        $asset = new MockAsset(['width' => 800, 'height' => 600]);
+        $asset->setFilename('data.zzzz');
+
+        $this->assertNull($asset->getMimeType());
+    }
+
     public function testFilenameConfigKeyIsHonored(): void
     {
         $asset = new MockAsset(['width' => 800, 'height' => 600, 'filename' => 'banner.webp']);

--- a/tests/unit/models/MockAssetTest.php
+++ b/tests/unit/models/MockAssetTest.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace viget\partskit\tests\unit\models;
+
+use Codeception\Test\Unit;
+use craft\elements\Asset;
+use UnitTester;
+use viget\partskit\models\MockAsset;
+use yii\base\NotSupportedException;
+
+/**
+ * U4 — MockAsset non-URL surface: construction/init defaults, metadata
+ * getters/setters, mode-aware dimension resolution, and NotSupportedException
+ * for DB-/volume-touching methods. URL emission is covered in U6.
+ *
+ * Transforms are passed as arrays (not named handles) so dimension math runs
+ * without a DB transform row — see the plan's Testing Strategy.
+ */
+class MockAssetTest extends Unit
+{
+    protected UnitTester $tester;
+
+    public function testConstructWithConfigSetsDimensions(): void
+    {
+        $asset = new MockAsset(['width' => 800, 'height' => 600]);
+
+        $this->assertSame(800, $asset->getWidth());
+        $this->assertSame(600, $asset->getHeight());
+    }
+
+    public function testInitDefaults(): void
+    {
+        $asset = new MockAsset(['width' => 800, 'height' => 600]);
+
+        $this->assertSame(Asset::KIND_IMAGE, $asset->kind);
+        $this->assertSame(-1, $asset->id);
+    }
+
+    public function testGetWidthHeightNoTransform(): void
+    {
+        $asset = new MockAsset(['width' => 1600, 'height' => 900]);
+
+        $this->assertSame(1600, $asset->getWidth());
+        $this->assertSame(900, $asset->getHeight());
+    }
+
+    public function testGetWidthFitTransformAspectPreserved(): void
+    {
+        // Covers AC5 — base 1600x900, fit to width 400 → 400x225.
+        $asset = new MockAsset(['width' => 1600, 'height' => 900]);
+
+        $this->assertSame(400, $asset->getWidth(['width' => 400, 'mode' => 'fit']));
+        $this->assertSame(225, $asset->getHeight(['width' => 400, 'mode' => 'fit']));
+    }
+
+    public function testGetWidthStretchVsFitDiffer(): void
+    {
+        // Mode-awareness: a 400x400 box fits 1600x900 to 400x225, but stretches
+        // to the full 400x400. Both width and height must be given for the modes
+        // to diverge.
+        $asset = new MockAsset(['width' => 1600, 'height' => 900]);
+
+        $fit = ['width' => 400, 'height' => 400, 'mode' => 'fit'];
+        $stretch = ['width' => 400, 'height' => 400, 'mode' => 'stretch'];
+
+        $this->assertSame(225, $asset->getHeight($fit));
+        $this->assertSame(400, $asset->getHeight($stretch));
+    }
+
+    public function testDefaultFilenameDerivedFromDimensions(): void
+    {
+        $asset = new MockAsset(['width' => 800, 'height' => 600]);
+
+        $this->assertSame('mock-800x600.png', $asset->getFilename());
+        $this->assertSame('png', $asset->getExtension());
+        $this->assertSame('image/png', $asset->getMimeType());
+    }
+
+    public function testSetFilenameDerivesExtensionAndMime(): void
+    {
+        $asset = new MockAsset(['width' => 800, 'height' => 600]);
+        $asset->setFilename('hero.jpg');
+
+        $this->assertSame('hero.jpg', $asset->getFilename());
+        $this->assertSame('jpg', $asset->getExtension());
+        $this->assertSame('image/jpeg', $asset->getMimeType());
+    }
+
+    public function testFilenameConfigKeyIsHonored(): void
+    {
+        $asset = new MockAsset(['width' => 800, 'height' => 600, 'filename' => 'banner.webp']);
+
+        $this->assertSame('banner.webp', $asset->getFilename());
+        $this->assertSame('image/webp', $asset->getMimeType());
+    }
+
+    public function testFocalPointDefaultsToNullAndHasFocalPointFalse(): void
+    {
+        $asset = new MockAsset(['width' => 800, 'height' => 600]);
+
+        $this->assertFalse($asset->getHasFocalPoint());
+        $this->assertNull($asset->getFocalPoint());
+    }
+
+    public function testFocalPointWhenSet(): void
+    {
+        $asset = new MockAsset([
+            'width' => 800,
+            'height' => 600,
+            'focalPoint' => ['x' => 0.25, 'y' => 0.75],
+        ]);
+
+        $this->assertTrue($asset->getHasFocalPoint());
+        $this->assertSame(['x' => 0.25, 'y' => 0.75], $asset->getFocalPoint());
+    }
+
+    public function testUnsupportedMethodThrowsWithMethodNameAndReadme(): void
+    {
+        // Covers AC10 — getVolume() throws, message names the method and README.
+        $asset = new MockAsset(['width' => 800, 'height' => 600]);
+
+        $this->expectException(NotSupportedException::class);
+        $this->expectExceptionMessageMatches('/getVolume.*README/s');
+
+        $asset->getVolume();
+    }
+
+    public function testUnsupportedFieldValueThrows(): void
+    {
+        // Covers AC10 — field access is unsupported on a mock.
+        $asset = new MockAsset(['width' => 800, 'height' => 600]);
+
+        $this->expectException(NotSupportedException::class);
+        $this->expectExceptionMessageMatches('/getFieldValue/');
+
+        $asset->getFieldValue('caption');
+    }
+}

--- a/tests/unit/models/MockAssetTest.php
+++ b/tests/unit/models/MockAssetTest.php
@@ -99,11 +99,24 @@ class MockAssetTest extends Unit
         $this->assertSame('image/webp', $asset->getMimeType());
     }
 
-    public function testFocalPointDefaultsToNullAndHasFocalPointFalse(): void
+    public function testFocalPointDefaultsToCenterAndHasFocalPointFalse(): void
     {
+        // Mirrors Craft: an image Asset with no focal point set reports
+        // hasFocalPoint=false but getFocalPoint() returns the center default,
+        // never null — so object-position CSS behaves identically for mocks.
         $asset = new MockAsset(['width' => 800, 'height' => 600]);
 
         $this->assertFalse($asset->getHasFocalPoint());
+        $this->assertSame(['x' => 0.5, 'y' => 0.5], $asset->getFocalPoint());
+        $this->assertSame('50% 50%', $asset->getFocalPoint(true));
+    }
+
+    public function testFocalPointIsNullForNonImageKind(): void
+    {
+        // Craft parity: non-visual kinds have no focal point at all.
+        $asset = new MockAsset(['width' => 800, 'height' => 600]);
+        $asset->kind = 'document';
+
         $this->assertNull($asset->getFocalPoint());
     }
 

--- a/tests/unit/models/MockAssetTest.php
+++ b/tests/unit/models/MockAssetTest.php
@@ -9,7 +9,9 @@ use UnitTester;
 use viget\partskit\models\MockAsset;
 use viget\partskit\models\MockAssetBuilder;
 use viget\partskit\Plugin;
+use viget\partskit\services\Assets;
 use yii\base\NotSupportedException;
+use yii\helpers\StringHelper;
 
 /**
  * U4 — MockAsset non-URL surface: construction/init defaults, metadata
@@ -210,10 +212,52 @@ class MockAssetTest extends Unit
         $this->assertCount(2, array_unique($urls), 'Each srcset size yields a distinct URL');
     }
 
+    public function testGetFocalPointAsCss(): void
+    {
+        $asset = new MockAsset([
+            'width' => 800,
+            'height' => 600,
+            'focalPoint' => ['x' => 0.25, 'y' => 0.75],
+        ]);
+
+        $this->assertSame('25% 75%', $asset->getFocalPoint(true));
+    }
+
+    public function testGetUrlAndImgAreNullWhenDimensionsAbsent(): void
+    {
+        // A MockAsset built with no dimensions can't form a URL.
+        $asset = new MockAsset([]);
+
+        $this->assertNull($asset->getUrl());
+        $this->assertNull($asset->getImg());
+    }
+
+    public function testGetSrcsetWidthDescriptorsEncodeRequestedWidths(): void
+    {
+        // The 'w' descriptor branch sets the transform width directly; assert the
+        // emitted URLs encode those widths in their signed payloads.
+        $asset = new MockAsset(['width' => 800, 'height' => 600]);
+
+        $srcset = $asset->getSrcset(['400w', '800w']);
+        $this->assertIsString($srcset);
+
+        $widths = [];
+        foreach (explode(', ', $srcset) as $entry) {
+            $url = explode(' ', $entry)[0];
+            preg_match('#/mock/([A-Za-z0-9_-]+)\.png#', $url, $matches);
+            $payload = Craft::$app->getSecurity()->validateData(
+                StringHelper::base64UrlDecode($matches[1]),
+            );
+            $widths[] = json_decode($payload, true)['w'];
+        }
+
+        $this->assertSame([400, 800], $widths);
+    }
+
     public function testRenderTouchesNoFilesystemAndNoImagick(): void
     {
         // Covers AC11 — emitting URLs/markup creates no files in the mocks dir.
-        $dir = Craft::getAlias('@storage/runtime/parts-kit-mocks');
+        $dir = Craft::getAlias(Assets::CACHE_DIRECTORY);
         $before = is_dir($dir) ? count(glob($dir . '/*') ?: []) : 0;
 
         $asset = new MockAsset(['width' => 800, 'height' => 600, 'label' => 'Hero']);

--- a/tests/unit/models/MockAssetTest.php
+++ b/tests/unit/models/MockAssetTest.php
@@ -3,9 +3,12 @@
 namespace viget\partskit\tests\unit\models;
 
 use Codeception\Test\Unit;
+use Craft;
 use craft\elements\Asset;
 use UnitTester;
 use viget\partskit\models\MockAsset;
+use viget\partskit\models\MockAssetBuilder;
+use viget\partskit\Plugin;
 use yii\base\NotSupportedException;
 
 /**
@@ -134,5 +137,91 @@ class MockAssetTest extends Unit
         $this->expectExceptionMessageMatches('/getFieldValue/');
 
         $asset->getFieldValue('caption');
+    }
+
+    // --- U6: transform-emitting URL methods ----------------------------------
+
+    public function testGetUrlEmitsSignedUrl(): void
+    {
+        // Covers AC1.
+        $asset = new MockAsset(['width' => 800, 'height' => 600]);
+
+        $this->assertMatchesRegularExpression(
+            '#/parts-kit/mock/[A-Za-z0-9_-]+\.png$#',
+            (string)$asset->getUrl(),
+        );
+    }
+
+    public function testGetUrlIsMemoized(): void
+    {
+        $asset = new MockAsset(['width' => 800, 'height' => 600]);
+
+        $this->assertSame($asset->getUrl(), $asset->getUrl());
+    }
+
+    public function testGetUrlWithTransformResolvesDimensions(): void
+    {
+        // getUrl with a fit-400 transform on a 1600x900 mock encodes 400x225.
+        $asset = new MockAsset(['width' => 1600, 'height' => 900, 'label' => 'Hero']);
+
+        $expected = Plugin::getInstance()->getAssets()->signedUrlForImage(400, 225, 'Hero');
+
+        $this->assertSame($expected, $asset->getUrl(['width' => 400, 'mode' => 'fit']));
+    }
+
+    public function testGetImgMarkup(): void
+    {
+        // Covers AC4.
+        $asset = (new MockAssetBuilder())
+            ->width(800)
+            ->height(600)
+            ->alt('Hero')
+            ->one();
+
+        $img = (string)$asset->getImg();
+
+        $this->assertStringContainsString('<img', $img);
+        $this->assertStringContainsString('width="800"', $img);
+        $this->assertStringContainsString('height="600"', $img);
+        $this->assertStringContainsString('alt="Hero"', $img);
+        $this->assertMatchesRegularExpression('#src="[^"]*/parts-kit/mock/[A-Za-z0-9_-]+\.png"#', $img);
+    }
+
+    public function testGetImgReturnsNullForNonImageKind(): void
+    {
+        $asset = new MockAsset(['width' => 800, 'height' => 600]);
+        $asset->kind = 'document';
+
+        $this->assertNull($asset->getImg());
+    }
+
+    public function testGetSrcsetReturnsNUrls(): void
+    {
+        // Covers AC12 — N sizes emit N distinct signed URLs.
+        $asset = new MockAsset(['width' => 800, 'height' => 600]);
+
+        $srcset = $asset->getSrcset(['1x', '2x']);
+        $this->assertIsString($srcset);
+
+        $entries = explode(', ', $srcset);
+        $this->assertCount(2, $entries);
+
+        $urls = array_map(fn(string $entry) => explode(' ', $entry)[0], $entries);
+        $this->assertCount(2, array_unique($urls), 'Each srcset size yields a distinct URL');
+    }
+
+    public function testRenderTouchesNoFilesystemAndNoImagick(): void
+    {
+        // Covers AC11 — emitting URLs/markup creates no files in the mocks dir.
+        $dir = Craft::getAlias('@storage/runtime/parts-kit-mocks');
+        $before = is_dir($dir) ? count(glob($dir . '/*') ?: []) : 0;
+
+        $asset = new MockAsset(['width' => 800, 'height' => 600, 'label' => 'Hero']);
+        $asset->getUrl();
+        $asset->getImg();
+        $asset->getSrcset(['1x', '2x']);
+
+        $after = is_dir($dir) ? count(glob($dir . '/*') ?: []) : 0;
+        $this->assertSame($before, $after, 'Rendering must not generate any files');
     }
 }

--- a/tests/unit/services/AssetsTest.php
+++ b/tests/unit/services/AssetsTest.php
@@ -3,21 +3,135 @@
 namespace viget\partskit\tests\unit\services;
 
 use Codeception\Test\Unit;
+use Craft;
+use craft\helpers\Json;
 use UnitTester;
 use viget\partskit\models\MockAssetBuilder;
 use viget\partskit\services\Assets;
+use yii\helpers\StringHelper;
 
 /**
- * Assets service. U1 only pins the make() entry point returning a builder;
- * config application, the Imagick boot check, and signedUrlForImage() arrive in
- * U5 and extend these cases rather than replacing them.
+ * Assets service — the make() entry point plus URL routing and HMAC signing.
+ *
+ * Signing round-trips in-process: the harness pins a fixed SECURITY_KEY, so
+ * sign → validate is deterministic and a one-byte mutation must fail validation.
+ * No HTTP is needed for the crypto itself (that's exercised end-to-end in
+ * MockControllerCest).
  */
 class AssetsTest extends Unit
 {
     protected UnitTester $tester;
 
+    private const ROUTE_PATTERN = '#/parts-kit/mock/[A-Za-z0-9_-]+\.png$#';
+
     public function testMakeReturnsBuilder(): void
     {
         $this->assertInstanceOf(MockAssetBuilder::class, (new Assets())->make());
+    }
+
+    public function testMakeReturnsConfiguredBuilder(): void
+    {
+        $asset = (new Assets())->make(['width' => 400])->one();
+
+        $this->assertSame(400, $asset->getWidth());
+    }
+
+    public function testMakeNoArgsReturnsEmptyBuilder(): void
+    {
+        $asset = (new Assets())->make()->one();
+
+        $this->assertSame(800, $asset->getWidth());
+        $this->assertSame(600, $asset->getHeight());
+    }
+
+    public function testSignedUrlMatchesRoutePattern(): void
+    {
+        // Covers AC1.
+        $url = (new Assets())->signedUrlForImage(800, 600, 'Hero');
+
+        $this->assertMatchesRegularExpression(self::ROUTE_PATTERN, $url);
+    }
+
+    public function testSignedTokenRoundTrips(): void
+    {
+        // NFR2 (positive): the validated payload decodes back to the inputs.
+        $url = (new Assets())->signedUrlForImage(800, 600, 'Hero');
+        $payload = $this->validatedPayload($url);
+
+        $this->assertNotFalse($payload);
+
+        $data = Json::decode($payload);
+        $this->assertSame(800, $data['w']);
+        $this->assertSame(600, $data['h']);
+        $this->assertSame('Hero', $data['label']);
+    }
+
+    public function testTamperedTokenFailsValidation(): void
+    {
+        // NFR2 (negative): flipping one token character breaks the signature.
+        $url = (new Assets())->signedUrlForImage(800, 600, 'Hero');
+        $token = $this->tokenFrom($url);
+
+        $mutated = $token;
+        $mutated[5] = $token[5] === 'A' ? 'B' : 'A';
+
+        $signed = StringHelper::base64UrlDecode($mutated);
+        $this->assertFalse(Craft::$app->getSecurity()->validateData($signed));
+    }
+
+    public function testIdenticalConfigProducesIdenticalUrlAndHash(): void
+    {
+        // Covers AC6 — same (w, h, label) → identical URL and identical
+        // on-disk hash.
+        $a = (new Assets())->signedUrlForImage(800, 600, 'Hero');
+        $b = (new Assets())->signedUrlForImage(800, 600, 'Hero');
+
+        $this->assertSame($a, $b);
+        $this->assertSame(
+            sha1($this->validatedPayload($a)),
+            sha1($this->validatedPayload($b)),
+        );
+    }
+
+    public function testDifferentLabelProducesDifferentHash(): void
+    {
+        // Covers AC7 — changing only the label changes the token and the hash.
+        $a = (new Assets())->signedUrlForImage(800, 600, 'Hero');
+        $b = (new Assets())->signedUrlForImage(800, 600, 'Thumbnail');
+
+        $this->assertNotSame($a, $b);
+        $this->assertNotSame(
+            sha1($this->validatedPayload($a)),
+            sha1($this->validatedPayload($b)),
+        );
+    }
+
+    public function testKeyedPayloadIsOrderStable(): void
+    {
+        // The payload encodes keys deterministically, so the hash is stable
+        // across calls.
+        $first = $this->validatedPayload((new Assets())->signedUrlForImage(800, 600, 'Hero'));
+        $second = $this->validatedPayload((new Assets())->signedUrlForImage(800, 600, 'Hero'));
+
+        $this->assertSame($first, $second);
+    }
+
+    private function tokenFrom(string $url): string
+    {
+        preg_match('#/mock/([A-Za-z0-9_-]+)\.png#', $url, $matches);
+
+        return $matches[1];
+    }
+
+    /**
+     * Decodes a mock URL's token and returns the HMAC-validated payload (or
+     * false if the signature does not verify) — mirroring what the controller
+     * does on each request.
+     */
+    private function validatedPayload(string $url): string|false
+    {
+        $signed = StringHelper::base64UrlDecode($this->tokenFrom($url));
+
+        return Craft::$app->getSecurity()->validateData($signed);
     }
 }


### PR DESCRIPTION
Phase 2 of the Mock Asset feature (plan: `docs/plans/2026-05-25-feat-mock-asset-service-plan.md`). Stacked on #25. Implements the full mock-asset core: a placeholder `Asset` element, a builder, HMAC-signed image URLs, lazy Imagick PNG generation, and the serving controller — so Parts Kit template authors can render placeholder images without uploading real assets.

## What's here (U3–U9)

- **`MockAsset`** — extends `craft\elements\Asset`, implementing only the surface real component templates use: mode-aware `getWidth/getHeight` (via Craft's `normalizeTransform` + `targetDimensions`), `getUrl/getImg/getSrcset/getUrlsBySize`, filename/extension/mimeType, focal point. DB/volume methods throw `NotSupportedException`. Render emits **signed URL strings only** — zero Imagick, zero filesystem.
- **`MockAssetBuilder`** — fluent + `configure()` array API; 800×600 defaults; label trimmed/capped at 200; dimensions bounded to 1–5000.
- **`Assets` service** — `make()` (+ Imagick boot guard), `signedUrlForImage()` (HMAC-signed, base64url token carrying `{w,h,label}`), and the cache-path owner (`sha1(payload).png` under `@storage/runtime/parts-kit-mocks/`).
- **`MockImageGenerator`** — the only generation path: Imagick PNG with a bundled-font-first fallback chain, atomic temp-file + rename, a 5,000-file cap, and temp-file cleanup on failure.
- **`MockController`** — signed-token route, Parts Kit permission gate **before** signature validation (uniform 403, no token oracle), lazy generation on cache miss, immutable cache headers.
- **`clear-caches`** integration empties the mock cache.

## Key decisions / notes

- **Tamper-proof, durable URLs.** The signed payload carries the validated config, so the controller regenerates on demand after a cache clear — no sidecar files, no DB.
- **Dimension bound (`MAX_DIMENSION = 5000`)** enforced at the builder *and* the controller — added during code review to prevent an oversized Imagick canvas (resource exhaustion).
- **Serving via raw-content response** rather than `sendFile`: the placeholder PNGs are tiny, and a streamed/flushed download response can't be driven by the functional test connector. Same `image/png` body + immutable cache.
- **`ext-imagick`** is required (landed in #25); CI already loads it.

## Testing

- 77 tests / 159 assertions green (unit + functional), ECS + PHPStan L4 clean.
- Unit: builder defaults/caps/bounds, dimension math, signing round-trip + tamper + hash identity, generator exact-dims/PNG-signature/atomic-write/cap, render-time zero-FS snapshot.
- Functional (`MockControllerCest`): 200 + headers + on-disk dims, cold-cache generation, tamper → 404, gate 403/200, gate-before-validation, out-of-range dimensions → 404, file-count-cap → 404.
- Reviewed by a multi-agent code-review pass (correctness, security, adversarial, testing, maintainability, reliability, api-contract, performance); P1 dimension-bound finding fixed.

## Known residuals (deferred to U12 docs)

- `MockAsset::getUrl` does not fire Asset `EVENT_DEFINE_URL` hooks (CDN/URL-rewriting plugins won't affect mock previews) — to be documented.
- `{directory}/mock/<token>.png` reserves that URL namespace; a user template at that path would be shadowed — to note in CHANGELOG/README.
- Focal point returns `null` by default (not Craft's `0.5/0.5` center) — intentional per the brainstorm decision; document array-only.

## Post-Deploy Monitoring & Validation

No production runtime impact for existing installs until a template calls `partsKit.assets.make(...)`. After merge, in an environment using mock assets: confirm `/parts-kit/mock/<token>.png` serves a PNG of the expected size, a tampered token returns 404, and `php craft clear-caches/all` empties `@storage/runtime/parts-kit-mocks/`. Watch for `RuntimeException` (missing Imagick/font) and `NotSupportedException` (a template calling an unsupported Asset method) in logs.

## Scope

Imager X integration (U10–U11) and docs/CHANGELOG/consumer audit (U12) are the remaining phases, in follow-up PRs.
